### PR TITLE
Modal 내부에서 contextmenu 사용 시 좌클릭으로 닫히지 않는 버그 해결

### DIFF
--- a/src/newtab/components/ContextMenu.vue
+++ b/src/newtab/components/ContextMenu.vue
@@ -14,13 +14,15 @@ export interface Position {
 
 export default defineComponent({
   mounted() {
-    window.addEventListener("click", this.onClickOutside);
+    window.addEventListener("mousedown", this.onClickOutside, {
+      capture: true,
+    });
     window.addEventListener("contextmenu", this.onClickOutside, {
       capture: true,
     });
   },
   unmounted() {
-    window.removeEventListener("click", this.onClickOutside);
+    window.removeEventListener("mousedown", this.onClickOutside);
     window.removeEventListener("contextmenu", this.onClickOutside);
   },
   props: {

--- a/src/newtab/components/ContextMenu.vue
+++ b/src/newtab/components/ContextMenu.vue
@@ -64,5 +64,6 @@ export default defineComponent({
   border: 1px solid black;
   background-color: white;
   min-width: 64px;
+  z-index: 1000;
 }
 </style>

--- a/src/newtab/components/ContextMenu.vue
+++ b/src/newtab/components/ContextMenu.vue
@@ -14,13 +14,13 @@ export interface Position {
 
 export default defineComponent({
   mounted() {
-    window.addEventListener("mousedown", this.onClickOutside);
+    window.addEventListener("click", this.onClickOutside);
     window.addEventListener("contextmenu", this.onClickOutside, {
       capture: true,
     });
   },
   unmounted() {
-    window.removeEventListener("mousedown", this.onClickOutside);
+    window.removeEventListener("click", this.onClickOutside);
     window.removeEventListener("contextmenu", this.onClickOutside);
   },
   props: {


### PR DESCRIPTION
- mousedown 이벤트에도 useCapture 부여
- contextmenu에 z-index를 높게 부여하여 modal의 아이템에 가려지지 않도록 수정