### PR TITLE
feat: CreateModal 컴포넌트, 폴더 생성기능 추가

### DIFF
--- a/src/newtab/components/Bookshelf.vue
+++ b/src/newtab/components/Bookshelf.vue
@@ -1,9 +1,12 @@
 <template>
-  <div class="grid-container">
+  <div
+    class="grid-container"
+    @contextmenu.prevent.stop="openContextMenu($event, 'BACKGROUND')"
+  >
     <div
       v-for="(item, i) in items"
       v-bind:key="i"
-      @contextmenu.prevent.stop="openContextMenu($event)"
+      @contextmenu.prevent.stop="openContextMenu($event, 'ITEM')"
     >
       <v-btn
         class="btn"
@@ -36,8 +39,18 @@
       </v-btn>
     </div>
     <ContextMenu v-model:show="showContextMenu" :position="contextMenuPosition">
-      <div class="context-menu-item">Edit</div>
-      <div class="context-menu-item">Delete</div>
+      <div
+        v-show="contextMenuTarget === 'BACKGROUND'"
+        class="context-menu-item"
+      >
+        Create Folder
+      </div>
+      <div v-show="contextMenuTarget === 'ITEM'" class="context-menu-item">
+        Edit
+      </div>
+      <div v-show="contextMenuTarget === 'ITEM'" class="context-menu-item">
+        Delete
+      </div>
     </ContextMenu>
   </div>
 </template>
@@ -53,6 +66,7 @@ export default defineComponent({
   data: () => ({
     showContextMenu: false,
     contextMenuPosition: { x: 0, y: 0 } as Position,
+    contextMenuTarget: "",
   }),
   props: {
     items: {
@@ -79,8 +93,9 @@ export default defineComponent({
     openUrl(id: string, url: string) {
       window.open(url, "_blank")?.focus();
     },
-    openContextMenu(event: PointerEvent) {
+    openContextMenu(event: PointerEvent, targetType: "ITEM" | "BACKGROUND") {
       this.contextMenuPosition = { x: event.clientX, y: event.clientY };
+      this.contextMenuTarget = targetType;
       this.showContextMenu = true;
     },
   },

--- a/src/newtab/components/Bookshelf.vue
+++ b/src/newtab/components/Bookshelf.vue
@@ -107,7 +107,7 @@ export default defineComponent({
       this.showContextMenu = false;
     },
     ...mapMutations({
-      setCreateModalInfo: `createModalModule/${SET_BOOKMARK_CREATE_INFO}`,
+      setCreateModalInfo: SET_BOOKMARK_CREATE_INFO,
     }),
   },
 });

--- a/src/newtab/components/Bookshelf.vue
+++ b/src/newtab/components/Bookshelf.vue
@@ -4,7 +4,7 @@
     @contextmenu.prevent.stop="openContextMenu($event, 'BACKGROUND')"
   >
     <div
-      v-for="(item, i) in items"
+      v-for="(item, i) in folderItem.children"
       v-bind:key="i"
       @contextmenu.prevent.stop="openContextMenu($event, 'ITEM')"
     >
@@ -57,7 +57,9 @@
 
 <script lang="ts">
 import { defineComponent, PropType } from "vue";
+import { mapMutations } from "vuex";
 import { Item } from "../../shared/types/store";
+import { SET_BOOKMARK_CREATE_INFO } from "../store/modules/createModal";
 import ContextMenu, { Position } from "./ContextMenu.vue";
 import Favicon from "./Favicon.vue";
 
@@ -69,26 +71,26 @@ export default defineComponent({
     contextMenuTarget: "",
   }),
   props: {
-    items: {
-      type: Array as PropType<Item[]>,
+    folderItem: {
+      type: Object as PropType<chrome.bookmarks.BookmarkTreeNode>,
       required: true,
     },
   },
   methods: {
     open(item: Item) {
-      const { title, children = [], parentId } = item;
+      const { parentId } = item;
       const isRootItem = parentId === "1";
       if (isRootItem) {
-        this.openBookshelfModal(title, children);
+        this.openBookshelfModal(item);
       } else {
-        this.openFolder(title, children);
+        this.openFolder(item);
       }
     },
-    openFolder(title: string, children: Item[]) {
-      this.$emit("openFolder", title, children);
+    openFolder(folderItem: Item) {
+      this.$emit("openFolder", folderItem);
     },
-    openBookshelfModal(title: string, children: Item[]) {
-      this.$emit("openBookshelfModal", title, children);
+    openBookshelfModal(folderItem: Item) {
+      this.$emit("openBookshelfModal", folderItem);
     },
     openUrl(id: string, url: string) {
       window.open(url, "_blank")?.focus();
@@ -98,6 +100,14 @@ export default defineComponent({
       this.contextMenuTarget = targetType;
       this.showContextMenu = true;
     },
+    openCreateModal() {
+      this.setCreateModalInfo({ parentId: this.folderItem.id });
+      this.$vfm.show("createModal");
+      this.showContextMenu = false;
+    },
+    ...mapMutations({
+      setCreateModalInfo: `createModalModule/${SET_BOOKMARK_CREATE_INFO}`,
+    }),
   },
 });
 </script>

--- a/src/newtab/components/Bookshelf.vue
+++ b/src/newtab/components/Bookshelf.vue
@@ -42,6 +42,7 @@
       <div
         v-show="contextMenuTarget === 'BACKGROUND'"
         class="context-menu-item"
+        @click="openCreateModal"
       >
         Create Folder
       </div>

--- a/src/newtab/components/BookshelfModal.vue
+++ b/src/newtab/components/BookshelfModal.vue
@@ -98,22 +98,19 @@ export default defineComponent({
 });
 </script>
 
-<style scoped>
-.modal-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
+<style lang="scss" scoped>
+.vfm::v-deep {
+  .modal-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  .modal-content {
+    position: relative;
+    width: 500px;
+    height: 500px;
+  }
 }
-.modal-content {
-  position: relative;
-  width: 500px;
-  height: 500px;
-}
-
-.modal-inner {
-  border: 1px solid lightgray;
-}
-
 .modal-banner {
   display: flex;
   justify-content: space-between;

--- a/src/newtab/components/BookshelfModal.vue
+++ b/src/newtab/components/BookshelfModal.vue
@@ -26,7 +26,7 @@
           <v-icon>mdi-close</v-icon>
         </button>
       </v-card-header>
-      <Bookshelf @openFolder="openFolder" :items="viewItem"> </Bookshelf>
+      <Bookshelf @openFolder="openFolder" :folderItem="viewItem"> </Bookshelf>
     </v-card>
   </vue-final-modal>
 </template>
@@ -40,17 +40,12 @@ export default defineComponent({
   data() {
     return {
       children: [] as Item[],
-      folderRoute: [] as string[],
-      items: [] as Item[][],
+      folderItems: [] as Item[],
     };
   },
   props: {
-    initItems: {
-      type: Array as PropType<Item[]>,
-      required: true,
-    },
-    initTitle: {
-      type: String,
+    initFolderItem: {
+      type: Object as PropType<Item>,
       required: true,
     },
     showBookshelfModal: {
@@ -63,36 +58,31 @@ export default defineComponent({
     },
   },
   created() {
-    this.items.push(this.initItems);
-    this.folderRoute.push(this.initTitle);
+    this.folderItems.push(this.initFolderItem);
   },
   computed: {
     showBackward() {
       return this.folderRoute.length > 1;
     },
     viewItem() {
-      return this.items[this.items.length - 1];
+      return this.folderItems[this.folderItems.length - 1];
     },
     _showBookshelfModal() {
       return this.showBookshelfModal;
+    },
+    folderRoute() {
+      return this.folderItems.map((item) => item.title);
     },
   },
   methods: {
     closeModal() {
       this.$emit("closeBookshelfModal");
     },
-
-    openFolder(title: string, children: Item[]) {
-      this.items.push(children);
-
-      this.addRoute(title);
-    },
-    addRoute(title: string) {
-      this.folderRoute.push(title);
+    openFolder(folderItem: Item) {
+      this.folderItems.push(folderItem);
     },
     backward() {
-      this.folderRoute.pop();
-      this.items.pop();
+      this.folderItems.pop();
     },
   },
 });

--- a/src/newtab/components/BookshelfModal.vue
+++ b/src/newtab/components/BookshelfModal.vue
@@ -99,12 +99,12 @@ export default defineComponent({
 </script>
 
 <style scoped>
-::v-deep .modal-container {
+.modal-container {
   display: flex;
   justify-content: center;
   align-items: center;
 }
-::v-deep .modal-content {
+.modal-content {
   position: relative;
   width: 500px;
   height: 500px;

--- a/src/newtab/components/CreateModal.vue
+++ b/src/newtab/components/CreateModal.vue
@@ -22,6 +22,7 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 import { mapGetters, mapMutations } from "vuex";
+import { SET_BOOKMARK_TREE } from "../store";
 import {
   GET_BOOKMARK_CREATE_INFO,
   GET_BOOKMARK_CREATE_SHOW,
@@ -58,8 +59,10 @@ export default defineComponent({
         folderName
       );
       if (createSuccessful) {
+        this.folderName = "";
         this.resetCreateModalInfo();
         this.setCreateModalShow(false);
+        this.setBookmarkTree(await BookmarkApi.getTree());
       }
     },
     closeCreateModal() {
@@ -68,6 +71,7 @@ export default defineComponent({
     ...mapMutations({
       resetCreateModalInfo: RESET_BOOKMARK_CREATE_INFO,
       setCreateModalShow: SET_BOOKMARK_CREATE_SHOW,
+      setBookmarkTree: SET_BOOKMARK_TREE,
     }),
   },
 });

--- a/src/newtab/components/CreateModal.vue
+++ b/src/newtab/components/CreateModal.vue
@@ -4,21 +4,28 @@
     :name="'createModal'"
     classes="modal-container"
   >
-    <v-card class="modal-content">createModal</v-card>
+    <v-card class="modal-content">
+      <h2 class="modal-title">Create Folder</h2>
+      <v-text-field label="Folder Name"></v-text-field>
+      <div class="button-group">
+        <v-btn color="success" class="mr-4">Create Folder</v-btn>
+        <v-btn color="error">Cancel</v-btn>
+      </div>
+    </v-card>
   </vue-final-modal>
 </template>
 
 <script>
-export default {
+import { defineComponent } from "vue";
+
+export default defineComponent({
   setup() {
     return {};
   },
-  data() {
-    return {
-      show: false,
-    };
-  },
-};
+  data: () => ({
+    show: false,
+  }),
+});
 </script>
 
 <style lang="scss" scoped>
@@ -28,7 +35,15 @@ export default {
   align-items: center;
 }
 .modal-content {
-  width: 300px;
-  height: 300px;
+  position: relative;
+  padding: 20px;
+}
+.modal-title {
+  margin-bottom: 16px;
+  text-align: center;
+}
+.button-group {
+  display: flex;
+  flex-direction: row;
 }
 </style>

--- a/src/newtab/components/CreateModal.vue
+++ b/src/newtab/components/CreateModal.vue
@@ -20,8 +20,11 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
-import { mapGetters } from "vuex";
-import { GET_BOOKMARK_CREATE_INFO } from "../store/modules/createModal";
+import { mapGetters, mapMutations } from "vuex";
+import {
+  GET_BOOKMARK_CREATE_INFO,
+  RESET_BOOKMARK_CREATE_INFO,
+} from "../store/modules/createModal";
 import BookmarkApi from "../utils/bookmarkApi";
 
 export default defineComponent({
@@ -44,12 +47,16 @@ export default defineComponent({
         folderName
       );
       if (createSuccessful) {
+        this.resetCreateModalInfo();
         this.show = false;
       }
     },
     closeCreateModal() {
       this.show = false;
     },
+    ...mapMutations({
+      resetCreateModalInfo: `createModalModule/${RESET_BOOKMARK_CREATE_INFO}`,
+    }),
   },
 });
 </script>

--- a/src/newtab/components/CreateModal.vue
+++ b/src/newtab/components/CreateModal.vue
@@ -3,8 +3,9 @@
     v-model="show"
     :name="'createModal'"
     classes="modal-container"
+    content-class="modal-content"
   >
-    <v-card class="modal-content">
+    <v-card class="modal-inner">
       <h2 class="modal-title">Create Folder</h2>
       <v-text-field label="Folder Name" v-model="folderName"></v-text-field>
       <div class="button-group">
@@ -52,13 +53,17 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.modal-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
+.vfm::v-deep {
+  .modal-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  .modal-content {
+    position: relative;
+  }
 }
-.modal-content {
-  position: relative;
+.modal-inner {
   padding: 20px;
 }
 .modal-title {

--- a/src/newtab/components/CreateModal.vue
+++ b/src/newtab/components/CreateModal.vue
@@ -6,17 +6,22 @@
   >
     <v-card class="modal-content">
       <h2 class="modal-title">Create Folder</h2>
-      <v-text-field label="Folder Name"></v-text-field>
+      <v-text-field label="Folder Name" v-model="folderName"></v-text-field>
       <div class="button-group">
-        <v-btn color="success" class="mr-4">Create Folder</v-btn>
+        <v-btn color="success" class="mr-4" @click="createFolder(folderName)"
+          >Create Folder</v-btn
+        >
         <v-btn color="error" @click="closeCreateModal">Cancel</v-btn>
       </div>
     </v-card>
   </vue-final-modal>
 </template>
 
-<script>
+<script lang="ts">
 import { defineComponent } from "vue";
+import { mapGetters } from "vuex";
+import { GET_BOOKMARK_TREE_ROOT } from "../store";
+import BookmarkApi from "../utils/bookmarkApi";
 
 export default defineComponent({
   setup() {
@@ -24,8 +29,21 @@ export default defineComponent({
   },
   data: () => ({
     show: false,
+    folderName: "",
   }),
+  computed: {
+    ...mapGetters({ bookmarkTreeRoot: GET_BOOKMARK_TREE_ROOT }),
+  },
   methods: {
+    async createFolder(folderName: string) {
+      const createSuccessful = await BookmarkApi.create(
+        this.bookmarkTreeRoot.id,
+        folderName
+      );
+      if (createSuccessful) {
+        this.show = false;
+      }
+    },
     closeCreateModal() {
       this.show = false;
     },

--- a/src/newtab/components/CreateModal.vue
+++ b/src/newtab/components/CreateModal.vue
@@ -4,6 +4,7 @@
     :name="'createModal'"
     classes="modal-container"
     content-class="modal-content"
+    z-index="1100"
   >
     <v-card class="modal-inner">
       <h2 class="modal-title">Create Folder</h2>

--- a/src/newtab/components/CreateModal.vue
+++ b/src/newtab/components/CreateModal.vue
@@ -51,4 +51,7 @@ export default defineComponent({
   display: flex;
   flex-direction: row;
 }
+::v-deep .v-field--active .v-field-label--floating {
+  transform: scale(0.75);
+}
 </style>

--- a/src/newtab/components/CreateModal.vue
+++ b/src/newtab/components/CreateModal.vue
@@ -21,7 +21,7 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 import { mapGetters } from "vuex";
-import { GET_BOOKMARK_TREE_ROOT } from "../store";
+import { GET_BOOKMARK_CREATE_INFO } from "../store/modules/createModal";
 import BookmarkApi from "../utils/bookmarkApi";
 
 export default defineComponent({
@@ -33,12 +33,14 @@ export default defineComponent({
     folderName: "",
   }),
   computed: {
-    ...mapGetters({ bookmarkTreeRoot: GET_BOOKMARK_TREE_ROOT }),
+    ...mapGetters({
+      createModalInfo: `createModalModule/${GET_BOOKMARK_CREATE_INFO}`,
+    }),
   },
   methods: {
     async createFolder(folderName: string) {
       const createSuccessful = await BookmarkApi.create(
-        this.bookmarkTreeRoot.id,
+        this.createModalInfo.parentId,
         folderName
       );
       if (createSuccessful) {

--- a/src/newtab/components/CreateModal.vue
+++ b/src/newtab/components/CreateModal.vue
@@ -24,7 +24,9 @@ import { defineComponent } from "vue";
 import { mapGetters, mapMutations } from "vuex";
 import {
   GET_BOOKMARK_CREATE_INFO,
+  GET_BOOKMARK_CREATE_SHOW,
   RESET_BOOKMARK_CREATE_INFO,
+  SET_BOOKMARK_CREATE_SHOW,
 } from "../store/modules/createModal";
 import BookmarkApi from "../utils/bookmarkApi";
 
@@ -33,13 +35,21 @@ export default defineComponent({
     return {};
   },
   data: () => ({
-    show: false,
     folderName: "",
   }),
   computed: {
     ...mapGetters({
-      createModalInfo: `createModalModule/${GET_BOOKMARK_CREATE_INFO}`,
+      createModalInfo: GET_BOOKMARK_CREATE_INFO,
+      createModalShow: GET_BOOKMARK_CREATE_SHOW,
     }),
+    show: {
+      get() {
+        return this.createModalShow;
+      },
+      set(newValue: boolean) {
+        this.setCreateModalShow(newValue);
+      },
+    },
   },
   methods: {
     async createFolder(folderName: string) {
@@ -49,14 +59,15 @@ export default defineComponent({
       );
       if (createSuccessful) {
         this.resetCreateModalInfo();
-        this.show = false;
+        this.setCreateModalShow(false);
       }
     },
     closeCreateModal() {
       this.show = false;
     },
     ...mapMutations({
-      resetCreateModalInfo: `createModalModule/${RESET_BOOKMARK_CREATE_INFO}`,
+      resetCreateModalInfo: RESET_BOOKMARK_CREATE_INFO,
+      setCreateModalShow: SET_BOOKMARK_CREATE_SHOW,
     }),
   },
 });

--- a/src/newtab/components/CreateModal.vue
+++ b/src/newtab/components/CreateModal.vue
@@ -1,0 +1,34 @@
+<template>
+  <vue-final-modal
+    v-model="show"
+    :name="'createModal'"
+    classes="modal-container"
+  >
+    <v-card class="modal-content">createModal</v-card>
+  </vue-final-modal>
+</template>
+
+<script>
+export default {
+  setup() {
+    return {};
+  },
+  data() {
+    return {
+      show: false,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.modal-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.modal-content {
+  width: 300px;
+  height: 300px;
+}
+</style>

--- a/src/newtab/components/CreateModal.vue
+++ b/src/newtab/components/CreateModal.vue
@@ -9,7 +9,7 @@
       <v-text-field label="Folder Name"></v-text-field>
       <div class="button-group">
         <v-btn color="success" class="mr-4">Create Folder</v-btn>
-        <v-btn color="error">Cancel</v-btn>
+        <v-btn color="error" @click="closeCreateModal">Cancel</v-btn>
       </div>
     </v-card>
   </vue-final-modal>
@@ -25,6 +25,11 @@ export default defineComponent({
   data: () => ({
     show: false,
   }),
+  methods: {
+    closeCreateModal() {
+      this.show = false;
+    },
+  },
 });
 </script>
 

--- a/src/newtab/pages/Desktop.vue
+++ b/src/newtab/pages/Desktop.vue
@@ -79,7 +79,7 @@ export default defineComponent({
   justify-content: center;
   align-items: center;
 }
-::v-deep .modal-content {
+.modal-content {
   position: relative;
   width: 500px;
   height: 500px;

--- a/src/newtab/pages/Desktop.vue
+++ b/src/newtab/pages/Desktop.vue
@@ -27,7 +27,7 @@ import Bookshelf from "../components/Bookshelf.vue";
 import BookshelfModal from "../components/BookshelfModal.vue";
 import ContextMenu, { Position } from "../components/ContextMenu.vue";
 import { mapGetters } from "vuex";
-import { GET_BOOKMARK_TREE } from "../store";
+import { GET_BOOKMARK_TREE_CHILDREN } from "../store";
 import CreateModal from "../components/CreateModal.vue";
 
 const OFFSET = 2;
@@ -41,7 +41,7 @@ export default defineComponent({
     showContextMenu: false,
   }),
   computed: {
-    ...mapGetters({ items: GET_BOOKMARK_TREE }),
+    ...mapGetters({ items: GET_BOOKMARK_TREE_CHILDREN }),
   },
   methods: {
     openBookshelfModal(title: string, children: Item[]) {

--- a/src/newtab/pages/Desktop.vue
+++ b/src/newtab/pages/Desktop.vue
@@ -1,16 +1,15 @@
 <template>
   <Bookshelf
     @openBookshelfModal="openBookshelfModal"
-    :items="items"
+    :folderItem="bookmarkTreeRoot"
     @contextmenu.prevent.stop="openContextMenu($event)"
   ></Bookshelf>
   <BookshelfModal
-    v-for="({ title, children, showBookshelfModal, zIndex }, i) in modals"
+    v-for="({ folderItem, showBookshelfModal, zIndex }, i) in modals"
     :key="i"
     @mousedown.capture="focusModal(i)"
     @closeBookshelfModal="closeBookshelfModal($event, i)"
-    :initItems="children"
-    :initTitle="title"
+    :initFolderItem="folderItem"
     :showBookshelfModal="showBookshelfModal"
     :zIndex="zIndex"
   ></BookshelfModal>
@@ -48,10 +47,9 @@ export default defineComponent({
     }),
   },
   methods: {
-    openBookshelfModal(title: string, children: Item[]) {
+    openBookshelfModal(folderItem: Item) {
       this.modals.push({
-        children: children,
-        title: title,
+        folderItem,
         showBookshelfModal: true,
         zIndex: (this.maxZIndex += OFFSET),
       });

--- a/src/newtab/pages/Desktop.vue
+++ b/src/newtab/pages/Desktop.vue
@@ -13,9 +13,6 @@
     :showBookshelfModal="showBookshelfModal"
     :zIndex="zIndex"
   ></BookshelfModal>
-  <ContextMenu v-model:show="showContextMenu" :position="contextMenuPosition">
-    <div class="context-menu-item" @click="openCreateModal">Create Folder</div>
-  </ContextMenu>
   <CreateModal />
 </template>
 
@@ -24,7 +21,7 @@ import { defineComponent } from "vue";
 import { Item, modalInfo } from "../../shared/types/store";
 import Bookshelf from "../components/Bookshelf.vue";
 import BookshelfModal from "../components/BookshelfModal.vue";
-import ContextMenu, { Position } from "../components/ContextMenu.vue";
+import { Position } from "../components/ContextMenu.vue";
 import { mapGetters, mapMutations } from "vuex";
 import { GET_BOOKMARK_TREE_CHILDREN, GET_BOOKMARK_TREE_ROOT } from "../store";
 import CreateModal from "../components/CreateModal.vue";
@@ -33,7 +30,7 @@ import { SET_BOOKMARK_CREATE_INFO } from "../store/modules/createModal";
 const OFFSET = 2;
 
 export default defineComponent({
-  components: { Bookshelf, BookshelfModal, ContextMenu, CreateModal },
+  components: { Bookshelf, BookshelfModal, CreateModal },
   data: () => ({
     modals: [] as modalInfo[],
     maxZIndex: 1000,

--- a/src/newtab/pages/Desktop.vue
+++ b/src/newtab/pages/Desktop.vue
@@ -26,9 +26,10 @@ import { Item, modalInfo } from "../../shared/types/store";
 import Bookshelf from "../components/Bookshelf.vue";
 import BookshelfModal from "../components/BookshelfModal.vue";
 import ContextMenu, { Position } from "../components/ContextMenu.vue";
-import { mapGetters } from "vuex";
-import { GET_BOOKMARK_TREE_CHILDREN } from "../store";
+import { mapGetters, mapMutations } from "vuex";
+import { GET_BOOKMARK_TREE_CHILDREN, GET_BOOKMARK_TREE_ROOT } from "../store";
 import CreateModal from "../components/CreateModal.vue";
+import { SET_BOOKMARK_CREATE_INFO } from "../store/modules/createModal";
 
 const OFFSET = 2;
 
@@ -41,7 +42,10 @@ export default defineComponent({
     showContextMenu: false,
   }),
   computed: {
-    ...mapGetters({ items: GET_BOOKMARK_TREE_CHILDREN }),
+    ...mapGetters({
+      items: GET_BOOKMARK_TREE_CHILDREN,
+      bookmarkTreeRoot: GET_BOOKMARK_TREE_ROOT,
+    }),
   },
   methods: {
     openBookshelfModal(title: string, children: Item[]) {
@@ -66,9 +70,13 @@ export default defineComponent({
       this.showContextMenu = true;
     },
     openCreateModal() {
+      this.setCreateModalInfo({ parentId: this.bookmarkTreeRoot.id });
       this.$vfm.show("createModal");
       this.showContextMenu = false;
     },
+    ...mapMutations({
+      setCreateModalInfo: `createModalModule/${SET_BOOKMARK_CREATE_INFO}`,
+    }),
   },
 });
 </script>

--- a/src/newtab/pages/Desktop.vue
+++ b/src/newtab/pages/Desktop.vue
@@ -74,26 +74,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-::v-deep .modal-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-.modal-content {
-  position: relative;
-  width: 500px;
-  height: 500px;
-}
-
-.modal-inner {
-  border: 1px solid lightgray;
-}
-
-.modal-banner {
-  display: flex;
-  justify-content: space-between;
-}
-
 .context-menu-item {
   padding: 4px 8px;
   &:hover {

--- a/src/newtab/pages/Desktop.vue
+++ b/src/newtab/pages/Desktop.vue
@@ -15,8 +15,9 @@
     :zIndex="zIndex"
   ></BookshelfModal>
   <ContextMenu v-model:show="showContextMenu" :position="contextMenuPosition">
-    <div class="context-menu-item">Create Folder</div>
+    <div class="context-menu-item" @click="openCreateModal">Create Folder</div>
   </ContextMenu>
+  <CreateModal />
 </template>
 
 <script lang="ts">
@@ -27,11 +28,12 @@ import BookshelfModal from "../components/BookshelfModal.vue";
 import ContextMenu, { Position } from "../components/ContextMenu.vue";
 import { mapGetters } from "vuex";
 import { GET_BOOKMARK_TREE } from "../store";
+import CreateModal from "../components/CreateModal.vue";
 
 const OFFSET = 2;
 
 export default defineComponent({
-  components: { Bookshelf, BookshelfModal, ContextMenu },
+  components: { Bookshelf, BookshelfModal, ContextMenu, CreateModal },
   data: () => ({
     modals: [] as modalInfo[],
     maxZIndex: 1000,
@@ -62,6 +64,10 @@ export default defineComponent({
     openContextMenu(event: PointerEvent) {
       this.contextMenuPosition = { x: event.clientX, y: event.clientY };
       this.showContextMenu = true;
+    },
+    openCreateModal() {
+      this.$vfm.show("createModal");
+      this.showContextMenu = false;
     },
   },
 });

--- a/src/newtab/store/index.ts
+++ b/src/newtab/store/index.ts
@@ -1,5 +1,6 @@
 import { Item } from "@/shared/types/store";
 import { createStore } from "vuex";
+import createModalModule from "./modules/createModal";
 
 export const GET_BOOKMARK_TREE_CHILDREN = "getBookmarkTree";
 export const GET_BOOKMARK_TREE_ROOT = "getBookmarkTreeRoot";
@@ -9,6 +10,7 @@ export interface State {
 }
 
 const store = createStore<State>({
+  modules: { createModalModule },
   state: {
     bookmarkTree: { title: "placeholder", id: "-1", children: [] } as Item,
   },

--- a/src/newtab/store/index.ts
+++ b/src/newtab/store/index.ts
@@ -1,18 +1,22 @@
 import { Item } from "@/shared/types/store";
 import { createStore } from "vuex";
 
-export const GET_BOOKMARK_TREE = "getBookmarkTree";
+export const GET_BOOKMARK_TREE_CHILDREN = "getBookmarkTree";
+export const GET_BOOKMARK_TREE_ROOT = "getBookmarkTreeRoot";
 export const SET_BOOKMARK_TREE = "setBookmarkTree";
 export interface State {
-  bookmarkTree: Item[];
+  bookmarkTree: Item;
 }
 
 const store = createStore<State>({
   state: {
-    bookmarkTree: [] as Item[],
+    bookmarkTree: { title: "placeholder", id: "-1", children: [] } as Item,
   },
   getters: {
-    [GET_BOOKMARK_TREE](state) {
+    [GET_BOOKMARK_TREE_CHILDREN](state) {
+      return state.bookmarkTree.children;
+    },
+    [GET_BOOKMARK_TREE_ROOT](state) {
       return state.bookmarkTree;
     },
   },

--- a/src/newtab/store/modules/createModal.ts
+++ b/src/newtab/store/modules/createModal.ts
@@ -1,0 +1,33 @@
+import { Module } from "vuex";
+import { State as RootState } from "../index";
+
+export const GET_BOOKMARK_CREATE_INFO = "getBookmarkCreateInfo";
+export const SET_BOOKMARK_CREATE_INFO = "setBookmarkCreateInfo";
+
+export interface State {
+  createModalInfo: {
+    parentId: string;
+  };
+}
+
+const createModalModule: Module<State, RootState> = {
+  namespaced: true,
+  state: {
+    createModalInfo: {
+      parentId: "",
+    },
+  },
+  getters: {
+    [GET_BOOKMARK_CREATE_INFO](state) {
+      return state.createModalInfo;
+    },
+  },
+  mutations: {
+    [SET_BOOKMARK_CREATE_INFO](state, _createModalInfo) {
+      state.createModalInfo = _createModalInfo;
+      console.log(state.createModalInfo);
+    },
+  },
+};
+
+export default createModalModule;

--- a/src/newtab/store/modules/createModal.ts
+++ b/src/newtab/store/modules/createModal.ts
@@ -4,32 +4,41 @@ import { State as RootState } from "../index";
 export const GET_BOOKMARK_CREATE_INFO = "getBookmarkCreateInfo";
 export const SET_BOOKMARK_CREATE_INFO = "setBookmarkCreateInfo";
 export const RESET_BOOKMARK_CREATE_INFO = "resetBookmarkCreateInfo";
+export const GET_BOOKMARK_CREATE_SHOW = "getBookmarkCreateShow";
+export const SET_BOOKMARK_CREATE_SHOW = "setBookmarkCreateShow";
 
 export interface State {
   createModalInfo: {
     parentId: string;
   };
+  createModalShow: boolean;
 }
 
 const createModalModule: Module<State, RootState> = {
-  namespaced: true,
+  namespaced: false,
   state: {
     createModalInfo: {
       parentId: "",
     },
+    createModalShow: false,
   },
   getters: {
     [GET_BOOKMARK_CREATE_INFO](state) {
       return state.createModalInfo;
+    },
+    [GET_BOOKMARK_CREATE_SHOW](state) {
+      return state.createModalShow;
     },
   },
   mutations: {
     [SET_BOOKMARK_CREATE_INFO](state, _createModalInfo) {
       state.createModalInfo = _createModalInfo;
     },
+    [SET_BOOKMARK_CREATE_SHOW](state, _createModalShow) {
+      state.createModalShow = _createModalShow;
+    },
     [RESET_BOOKMARK_CREATE_INFO](state) {
       state.createModalInfo = { parentId: "" };
-      console.log(state.createModalInfo);
     },
   },
 };

--- a/src/newtab/store/modules/createModal.ts
+++ b/src/newtab/store/modules/createModal.ts
@@ -3,6 +3,7 @@ import { State as RootState } from "../index";
 
 export const GET_BOOKMARK_CREATE_INFO = "getBookmarkCreateInfo";
 export const SET_BOOKMARK_CREATE_INFO = "setBookmarkCreateInfo";
+export const RESET_BOOKMARK_CREATE_INFO = "resetBookmarkCreateInfo";
 
 export interface State {
   createModalInfo: {
@@ -25,6 +26,9 @@ const createModalModule: Module<State, RootState> = {
   mutations: {
     [SET_BOOKMARK_CREATE_INFO](state, _createModalInfo) {
       state.createModalInfo = _createModalInfo;
+    },
+    [RESET_BOOKMARK_CREATE_INFO](state) {
+      state.createModalInfo = { parentId: "" };
       console.log(state.createModalInfo);
     },
   },

--- a/src/newtab/utils/bookmarkApi.ts
+++ b/src/newtab/utils/bookmarkApi.ts
@@ -1,11 +1,11 @@
 import { Item } from "@/shared/types/store";
 
 class BookmarkApi {
-  static async getTree(): Promise<Item[]> {
+  static async getTree(): Promise<Item> {
     const bookMarks = await chrome.bookmarks.getTree();
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [main, _] = bookMarks[0].children || [];
-    return main.children || [];
+    return main;
   }
 
   static async create(

--- a/src/shared/types/store.ts
+++ b/src/shared/types/store.ts
@@ -1,8 +1,7 @@
 export type Item = chrome.bookmarks.BookmarkTreeNode;
 
 export type modalInfo = {
-  children: Item[];
-  title: string;
+  folderItem: Item;
   showBookshelfModal: boolean;
   zIndex: number;
 };


### PR DESCRIPTION
- CreateModal 컴포넌트 추가
- ContextMenu에서 'Create Folder' 버튼 클릭 시 CreateModal 보이도록 연결
- 'Create Folder' 버튼이 눌린 위치에서 CreateModal로 parentId (새로운 폴더가 생길 디렉토리 id)를 전달하기 위해서 Bookshelf, BookshelfModal이 items, title 대신 folder node 자체를 props으로 받도록 리팩토링