### PR TITLE
feat: 폴더 모달창 제목의 마지막 아이템이 희미하게 나오지 않도록 수정

### DIFF
--- a/src/newtab/components/BookshelfModal.vue
+++ b/src/newtab/components/BookshelfModal.vue
@@ -35,12 +35,17 @@ import { defineComponent, PropType } from "vue";
 import { Item } from "../../shared/types/store";
 import Bookshelf from "./Bookshelf.vue";
 
+interface BreadCrumb {
+  disabled: boolean;
+  text: string | number;
+}
+
 export default defineComponent({
   components: { Bookshelf },
   data() {
     return {
       children: [] as Item[],
-      folderRoute: [] as string[],
+      folderRoute: [] as BreadCrumb[],
       items: [] as Item[][],
     };
   },
@@ -64,7 +69,7 @@ export default defineComponent({
   },
   created() {
     this.items.push(this.initItems);
-    this.folderRoute.push(this.initTitle);
+    this.addRoute(this.initTitle);
   },
   computed: {
     showBackward() {
@@ -84,11 +89,10 @@ export default defineComponent({
 
     openFolder(title: string, children: Item[]) {
       this.items.push(children);
-
       this.addRoute(title);
     },
     addRoute(title: string) {
-      this.folderRoute.push(title);
+      this.folderRoute.push({ text: title, disabled: false });
     },
     backward() {
       this.folderRoute.pop();


### PR DESCRIPTION
## Summary
- Vuetify의 Breadcrumb은 기본적으로 location.path 기반이고, 개별 subpath를 클릭해서 이동할 수 있도록 설계됨
- 마지막 아이템(=현재 위치)는 클릭되지 않도록 disable 스타일을 가지도록 설정되어있음
- 직접 breadcrumbs의 items props에 disabled=false 설정을 가진 객체를 넘겨서 마지막 아이템도 희미하지 않게 표현되도록 수정

## Reference
- https://vuetifyjs.com/en/api/v-breadcrumbs/#props-items