### PR TITLE
feat: ContextMenu 싱글톤, 전역상태로 이동

### DIFF
--- a/src/newtab/components/Bookshelf.vue
+++ b/src/newtab/components/Bookshelf.vue
@@ -1,10 +1,6 @@
 <template>
   <div class="grid-container">
-    <div
-      v-for="(item, i) in items"
-      v-bind:key="i"
-      @contextmenu.prevent.stop="openContextMenu($event)"
-    >
+    <div v-for="(item, i) in items" v-bind:key="i">
       <v-btn
         class="btn"
         tile
@@ -35,25 +31,16 @@
         </div>
       </v-btn>
     </div>
-    <ContextMenu v-model:show="showContextMenu" :position="contextMenuPosition">
-      <div class="context-menu-item">Edit</div>
-      <div class="context-menu-item">Delete</div>
-    </ContextMenu>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent, PropType } from "vue";
 import { Item } from "../../shared/types/store";
-import ContextMenu, { Position } from "./ContextMenu.vue";
 import Favicon from "./Favicon.vue";
 
 export default defineComponent({
-  components: { ContextMenu, Favicon },
-  data: () => ({
-    showContextMenu: false,
-    contextMenuPosition: { x: 0, y: 0 } as Position,
-  }),
+  components: { Favicon },
   props: {
     items: {
       type: Array as PropType<Item[]>,
@@ -78,10 +65,6 @@ export default defineComponent({
     },
     openUrl(id: string, url: string) {
       window.open(url, "_blank")?.focus();
-    },
-    openContextMenu(event: PointerEvent) {
-      this.contextMenuPosition = { x: event.clientX, y: event.clientY };
-      this.showContextMenu = true;
     },
   },
 });

--- a/src/newtab/components/Bookshelf.vue
+++ b/src/newtab/components/Bookshelf.vue
@@ -7,6 +7,9 @@
         elevation="0"
         @dblclick="open(item)"
         v-if="item.children"
+        @contextmenu.prevent.stop="
+          openContextMenu($event, { id: item.id, type: 'FOLDER' })
+        "
       >
         <div class="item-container">
           <v-icon class="item-icon">mdi-folder</v-icon>
@@ -22,6 +25,9 @@
         tile
         elevation="0"
         @dblclick="openUrl(item.id, item.url)"
+        @contextmenu.prevent.stop="
+          openContextMenu($event, { id: item.id, type: 'FILE' })
+        "
       >
         <div class="item-container">
           <Favicon :url="item.url" />
@@ -37,6 +43,7 @@
 <script lang="ts">
 import { defineComponent, PropType } from "vue";
 import { Item } from "../../shared/types/store";
+import { openContextMenu } from "../utils/contextMenu";
 import Favicon from "./Favicon.vue";
 
 export default defineComponent({
@@ -49,23 +56,24 @@ export default defineComponent({
   },
   methods: {
     open(item: Item) {
-      const { title, children = [], parentId } = item;
+      const { id, title, children = [], parentId } = item;
       const isRootItem = parentId === "1";
       if (isRootItem) {
-        this.openBookshelfModal(title, children);
+        this.openBookshelfModal(id, title, children);
       } else {
-        this.openFolder(title, children);
+        this.openFolder(id, title, children);
       }
     },
-    openFolder(title: string, children: Item[]) {
-      this.$emit("openFolder", title, children);
+    openFolder(targetId: string, title: string, children: Item[]) {
+      this.$emit("openFolder", targetId, title, children);
     },
-    openBookshelfModal(title: string, children: Item[]) {
-      this.$emit("openBookshelfModal", title, children);
+    openBookshelfModal(targetId: string, title: string, children: Item[]) {
+      this.$emit("openBookshelfModal", targetId, title, children);
     },
     openUrl(id: string, url: string) {
       window.open(url, "_blank")?.focus();
     },
+    openContextMenu,
   },
 });
 </script>

--- a/src/newtab/components/ContextMenu.vue
+++ b/src/newtab/components/ContextMenu.vue
@@ -1,16 +1,18 @@
 <template>
-  <div v-show="show" class="context-menu" :style="cssVars" ref="container">
+  <div v-show="isShow" class="context-menu" :style="cssVars" ref="container">
     <slot></slot>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from "@vue/runtime-core";
-
-export interface Position {
-  x: number;
-  y: number;
-}
+import store from "../store/index";
+import { mapGetters } from "vuex";
+import {
+  GET_CONTEXT_MENU_CSS_VARS,
+  GET_CONTEXT_MENU_SHOW_STATE,
+  SET_CONTEXT_MENU_SHOW_STATE,
+} from "../store/modules/contextMenu";
 
 export default defineComponent({
   mounted() {
@@ -25,24 +27,9 @@ export default defineComponent({
     window.removeEventListener("mousedown", this.onClickOutside);
     window.removeEventListener("contextmenu", this.onClickOutside);
   },
-  props: {
-    show: {
-      type: Boolean,
-      required: true,
-    },
-    position: {
-      type: Object,
-      required: true,
-    },
-  },
-  emits: ["update:show"],
   computed: {
-    cssVars() {
-      return {
-        "--top": `${this.position.y}px`,
-        "--left": `${this.position.x}px`,
-      };
-    },
+    ...mapGetters({ cssVars: GET_CONTEXT_MENU_CSS_VARS }),
+    ...mapGetters({ isShow: GET_CONTEXT_MENU_SHOW_STATE }),
   },
   methods: {
     onClickOutside(event: MouseEvent) {
@@ -51,7 +38,7 @@ export default defineComponent({
       const parentContextMenu = targetElement.closest(".context-menu");
       const clickedOutside = parentContextMenu !== this.$refs.container;
       if (clickedOutside) {
-        this.$emit("update:show", false);
+        store.commit(SET_CONTEXT_MENU_SHOW_STATE, false);
       }
     },
   },

--- a/src/newtab/components/ContextMenu/ContextMenu.vue
+++ b/src/newtab/components/ContextMenu/ContextMenu.vue
@@ -1,20 +1,29 @@
 <template>
-  <div v-show="isShow" class="context-menu" :style="cssVars" ref="container">
-    <slot></slot>
+  <div
+    v-show="isShow"
+    v-if="currentTarget"
+    class="context-menu"
+    :style="cssVars"
+    ref="container"
+  >
+    <MenuItem :target="currentTarget" />
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from "@vue/runtime-core";
-import store from "../store/index";
+import MenuItem from "./MenuItem.vue";
+import store from "../../store/index";
 import { mapGetters } from "vuex";
 import {
   GET_CONTEXT_MENU_CSS_VARS,
   GET_CONTEXT_MENU_SHOW_STATE,
+  GET_CONTEXT_MENU_TARGET,
   SET_CONTEXT_MENU_SHOW_STATE,
-} from "../store/modules/contextMenu";
+} from "../../store/modules/contextMenu";
 
 export default defineComponent({
+  components: { MenuItem },
   mounted() {
     window.addEventListener("mousedown", this.onClickOutside, {
       capture: true,
@@ -30,6 +39,7 @@ export default defineComponent({
   computed: {
     ...mapGetters({ cssVars: GET_CONTEXT_MENU_CSS_VARS }),
     ...mapGetters({ isShow: GET_CONTEXT_MENU_SHOW_STATE }),
+    ...mapGetters({ currentTarget: GET_CONTEXT_MENU_TARGET }),
   },
   methods: {
     onClickOutside(event: MouseEvent) {
@@ -53,6 +63,6 @@ export default defineComponent({
   border: 1px solid black;
   background-color: white;
   min-width: 64px;
-  z-index: 1000;
+  z-index: 2147483647;
 }
 </style>

--- a/src/newtab/components/ContextMenu/MenuItem.vue
+++ b/src/newtab/components/ContextMenu/MenuItem.vue
@@ -1,0 +1,42 @@
+<template>
+  <div
+    class="context-menu-wrapper"
+    v-if="target.type === 'FOLDER' || target.type === 'FILE'"
+  >
+    <button class="context-menu-item">Edit</button>
+    <button class="context-menu-item">Delete</button>
+  </div>
+  <div class="context-menu-wrapper" v-else>
+    <button class="context-menu-item">Create File</button>
+    <button class="context-menu-item">Create Folder</button>
+  </div>
+</template>
+
+<script lang="ts">
+import { ContextMenuTarget } from "@/newtab/store/modules/contextMenu";
+import { defineComponent, PropType } from "@vue/runtime-core";
+export default defineComponent({
+  props: {
+    target: {
+      require: true,
+      type: Object as PropType<ContextMenuTarget>,
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.context-menu-wrapper {
+  display: flex;
+  flex-direction: column;
+
+  .context-menu-item {
+    padding: 4px 8px;
+    text-align: start;
+    &:hover {
+      background-color: rgba(54, 69, 79, 0.2);
+      cursor: pointer;
+    }
+  }
+}
+</style>

--- a/src/newtab/pages/Desktop.vue
+++ b/src/newtab/pages/Desktop.vue
@@ -2,21 +2,24 @@
   <Bookshelf
     @openBookshelfModal="openBookshelfModal"
     :items="items"
-    @contextmenu.prevent.stop="openContextMenu($event)"
+    @contextmenu.prevent.stop="
+      openContextMenu($event, { id: '1', type: 'BACKGROUND' })
+    "
   ></Bookshelf>
   <BookshelfModal
-    v-for="({ title, children, showBookshelfModal, zIndex }, i) in modals"
+    v-for="(
+      { targetId, title, children, showBookshelfModal, zIndex }, i
+    ) in modals"
     :key="i"
     @mousedown.capture="focusModal(i)"
     @closeBookshelfModal="closeBookshelfModal($event, i)"
+    :targetId="targetId"
     :initItems="children"
     :initTitle="title"
     :showBookshelfModal="showBookshelfModal"
     :zIndex="zIndex"
   ></BookshelfModal>
-  <ContextMenu>
-    <div class="context-menu-item">Create Folder</div>
-  </ContextMenu>
+  <ContextMenu />
 </template>
 
 <script lang="ts">
@@ -24,13 +27,10 @@ import { defineComponent } from "vue";
 import { Item, modalInfo } from "../../shared/types/store";
 import Bookshelf from "../components/Bookshelf.vue";
 import BookshelfModal from "../components/BookshelfModal.vue";
-import ContextMenu from "../components/ContextMenu.vue";
+import ContextMenu from "../components/ContextMenu/ContextMenu.vue";
 import { mapGetters } from "vuex";
-import store, { GET_BOOKMARK_TREE } from "../store";
-import {
-  SET_CONTEXT_MENU_SHOW_STATE,
-  SET_CONTEXT_MENU_POSITION,
-} from "../store/modules/contextMenu";
+import { GET_BOOKMARK_TREE } from "../store";
+import { openContextMenu } from "../utils/contextMenu";
 
 const OFFSET = 2;
 
@@ -45,10 +45,11 @@ export default defineComponent({
     ...mapGetters({ items: GET_BOOKMARK_TREE }),
   },
   methods: {
-    openBookshelfModal(title: string, children: Item[]) {
+    openBookshelfModal(targetId: string, title: string, children: Item[]) {
       this.modals.push({
-        children: children,
-        title: title,
+        targetId,
+        children,
+        title,
         showBookshelfModal: true,
         zIndex: (this.maxZIndex += OFFSET),
       });
@@ -62,13 +63,7 @@ export default defineComponent({
     focusModal(idx: number) {
       this.modals[idx].zIndex = this.maxZIndex += OFFSET;
     },
-    openContextMenu(event: PointerEvent) {
-      store.commit(SET_CONTEXT_MENU_POSITION, {
-        x: event.clientX,
-        y: event.clientY,
-      });
-      store.commit(SET_CONTEXT_MENU_SHOW_STATE, true);
-    },
+    openContextMenu,
   },
 });
 </script>
@@ -92,13 +87,5 @@ export default defineComponent({
 .modal-banner {
   display: flex;
   justify-content: space-between;
-}
-
-.context-menu-item {
-  padding: 4px 8px;
-  &:hover {
-    background-color: rgba(54, 69, 79, 0.2);
-    cursor: pointer;
-  }
 }
 </style>

--- a/src/newtab/pages/Desktop.vue
+++ b/src/newtab/pages/Desktop.vue
@@ -14,7 +14,7 @@
     :showBookshelfModal="showBookshelfModal"
     :zIndex="zIndex"
   ></BookshelfModal>
-  <ContextMenu v-model:show="showContextMenu" :position="contextMenuPosition">
+  <ContextMenu>
     <div class="context-menu-item">Create Folder</div>
   </ContextMenu>
 </template>
@@ -24,9 +24,13 @@ import { defineComponent } from "vue";
 import { Item, modalInfo } from "../../shared/types/store";
 import Bookshelf from "../components/Bookshelf.vue";
 import BookshelfModal from "../components/BookshelfModal.vue";
-import ContextMenu, { Position } from "../components/ContextMenu.vue";
+import ContextMenu from "../components/ContextMenu.vue";
 import { mapGetters } from "vuex";
-import { GET_BOOKMARK_TREE } from "../store";
+import store, { GET_BOOKMARK_TREE } from "../store";
+import {
+  SET_CONTEXT_MENU_SHOW_STATE,
+  SET_CONTEXT_MENU_POSITION,
+} from "../store/modules/contextMenu";
 
 const OFFSET = 2;
 
@@ -35,7 +39,6 @@ export default defineComponent({
   data: () => ({
     modals: [] as modalInfo[],
     maxZIndex: 1000,
-    contextMenuPosition: { x: 0, y: 0 } as Position,
     showContextMenu: false,
   }),
   computed: {
@@ -60,8 +63,11 @@ export default defineComponent({
       this.modals[idx].zIndex = this.maxZIndex += OFFSET;
     },
     openContextMenu(event: PointerEvent) {
-      this.contextMenuPosition = { x: event.clientX, y: event.clientY };
-      this.showContextMenu = true;
+      store.commit(SET_CONTEXT_MENU_POSITION, {
+        x: event.clientX,
+        y: event.clientY,
+      });
+      store.commit(SET_CONTEXT_MENU_SHOW_STATE, true);
     },
   },
 });

--- a/src/newtab/store/index.ts
+++ b/src/newtab/store/index.ts
@@ -1,13 +1,16 @@
 import { Item } from "@/shared/types/store";
 import { createStore } from "vuex";
+import contextMenu from "./modules/contextMenu";
 
 export const GET_BOOKMARK_TREE = "getBookmarkTree";
 export const SET_BOOKMARK_TREE = "setBookmarkTree";
-export interface State {
+
+export interface RootState {
   bookmarkTree: Item[];
 }
 
-const store = createStore<State>({
+const store = createStore<RootState>({
+  modules: { contextMenu },
   state: {
     bookmarkTree: [] as Item[],
   },

--- a/src/newtab/store/modules/contextMenu.ts
+++ b/src/newtab/store/modules/contextMenu.ts
@@ -1,0 +1,48 @@
+import { Module } from "vuex";
+import { RootState } from "../index";
+
+export const SET_CONTEXT_MENU_SHOW_STATE = "contextMenu/setShow";
+export const SET_CONTEXT_MENU_POSITION = "contextMenu/setPosition";
+
+export const GET_CONTEXT_MENU_CSS_VARS = "contextMenu/getCssVars";
+export const GET_CONTEXT_MENU_SHOW_STATE = "contextMenu/getShow";
+
+export type Position = {
+  x: number;
+  y: number;
+};
+
+export type State = {
+  isShow: boolean;
+  position: Position;
+};
+
+const contextMenuModule: Module<State, RootState> = {
+  namespaced: true,
+  state: () => ({
+    isShow: false,
+    position: { x: 0, y: 0 },
+  }),
+  mutations: {
+    setShow(state, payload: boolean) {
+      state.isShow = payload;
+    },
+    setPosition(state, payload: Position) {
+      state.position = payload;
+    },
+  },
+  getters: {
+    getCssVars(state) {
+      return {
+        "--top": `${state.position.y}px`,
+        "--left": `${state.position.x}px`,
+      };
+    },
+    getShow(state) {
+      return state.isShow;
+    },
+  },
+  actions: {},
+};
+
+export default contextMenuModule;

--- a/src/newtab/store/modules/contextMenu.ts
+++ b/src/newtab/store/modules/contextMenu.ts
@@ -3,18 +3,26 @@ import { RootState } from "../index";
 
 export const SET_CONTEXT_MENU_SHOW_STATE = "contextMenu/setShow";
 export const SET_CONTEXT_MENU_POSITION = "contextMenu/setPosition";
+export const SET_CONTEXT_MENU_TARGET = "contextMenu/setTarget";
 
 export const GET_CONTEXT_MENU_CSS_VARS = "contextMenu/getCssVars";
 export const GET_CONTEXT_MENU_SHOW_STATE = "contextMenu/getShow";
+export const GET_CONTEXT_MENU_TARGET = "contextMenu/getTarget";
 
 export type Position = {
   x: number;
   y: number;
 };
 
+export type ContextMenuTarget = {
+  id: string;
+  type: "FILE" | "FOLDER" | "BACKGROUND";
+};
+
 export type State = {
   isShow: boolean;
   position: Position;
+  target?: ContextMenuTarget;
 };
 
 const contextMenuModule: Module<State, RootState> = {
@@ -30,6 +38,9 @@ const contextMenuModule: Module<State, RootState> = {
     setPosition(state, payload: Position) {
       state.position = payload;
     },
+    setTarget(state, payload: ContextMenuTarget) {
+      state.target = payload;
+    },
   },
   getters: {
     getCssVars(state) {
@@ -40,6 +51,9 @@ const contextMenuModule: Module<State, RootState> = {
     },
     getShow(state) {
       return state.isShow;
+    },
+    getTarget(state) {
+      return state.target;
     },
   },
   actions: {},

--- a/src/newtab/utils/contextMenu.ts
+++ b/src/newtab/utils/contextMenu.ts
@@ -1,0 +1,19 @@
+import {
+  ContextMenuTarget,
+  SET_CONTEXT_MENU_TARGET,
+  SET_CONTEXT_MENU_SHOW_STATE,
+  SET_CONTEXT_MENU_POSITION,
+} from "./../store/modules/contextMenu";
+import store from "../store/index";
+
+export const openContextMenu = (
+  event: PointerEvent,
+  target: ContextMenuTarget
+): void => {
+  store.commit(SET_CONTEXT_MENU_TARGET, target);
+  store.commit(SET_CONTEXT_MENU_POSITION, {
+    x: event.clientX,
+    y: event.clientY,
+  });
+  store.commit(SET_CONTEXT_MENU_SHOW_STATE, true);
+};

--- a/src/shared/types/store.ts
+++ b/src/shared/types/store.ts
@@ -1,6 +1,7 @@
 export type Item = chrome.bookmarks.BookmarkTreeNode;
 
 export type modalInfo = {
+  targetId: string;
   children: Item[];
   title: string;
   showBookshelfModal: boolean;


### PR DESCRIPTION
- ContextMenu를 Desktop에서만 사용하게 이동
- 전역상태로 `isShow`, `target`을 상태관리
- target의 타입을`BACKGROUND`, `FILE`, `FOLDER`로 타입을 나눠서 관리

### TODO

- [ ] 삭제 API 연결
- [ ] ContextMenu를 끄는 부분을 전역상태랑 연결

close #21 