### PR TITLE
feat: updateModal 컴포넌트, 폴더 생성기능 추가

### DIFF
--- a/src/newtab/components/Bookshelf.vue
+++ b/src/newtab/components/Bookshelf.vue
@@ -3,7 +3,7 @@
     <div
       v-for="(item, i) in items"
       v-bind:key="i"
-      @contextmenu.prevent.stop="openContextMenu($event)"
+      @contextmenu.prevent.stop="openContextMenu($event, item)"
     >
       <v-btn
         class="btn"
@@ -36,7 +36,7 @@
       </v-btn>
     </div>
     <ContextMenu v-model:show="showContextMenu" :position="contextMenuPosition">
-      <div class="context-menu-item">Edit</div>
+      <div class="context-menu-item" @click="openBookmarkModal">Edit</div>
       <div class="context-menu-item">Delete</div>
     </ContextMenu>
   </div>
@@ -47,12 +47,14 @@ import { defineComponent, PropType } from "vue";
 import { Item } from "../../shared/types/store";
 import ContextMenu, { Position } from "./ContextMenu.vue";
 import Favicon from "./Favicon.vue";
-
+import { mapActions } from "vuex";
+import { OPEN_BOOKMARK_UPDATE } from "../store/modules/updateModal";
 export default defineComponent({
   components: { ContextMenu, Favicon },
   data: () => ({
     showContextMenu: false,
     contextMenuPosition: { x: 0, y: 0 } as Position,
+    targetItem: {} as Item,
   }),
   props: {
     items: {
@@ -61,6 +63,10 @@ export default defineComponent({
     },
   },
   methods: {
+    ...mapActions([OPEN_BOOKMARK_UPDATE]),
+    openBookmarkModal() {
+      this[OPEN_BOOKMARK_UPDATE](this.targetItem);
+    },
     open(item: Item) {
       const { title, children = [], parentId } = item;
       const isRootItem = parentId === "1";
@@ -79,9 +85,10 @@ export default defineComponent({
     openUrl(id: string, url: string) {
       window.open(url, "_blank")?.focus();
     },
-    openContextMenu(event: PointerEvent) {
+    openContextMenu(event: PointerEvent, item: Item) {
       this.contextMenuPosition = { x: event.clientX, y: event.clientY };
       this.showContextMenu = true;
+      this.targetItem = item;
     },
   },
 });

--- a/src/newtab/components/UpdateModal.vue
+++ b/src/newtab/components/UpdateModal.vue
@@ -5,6 +5,7 @@
     content-class="modal-content"
     overlay-class="modal-overlay"
     :drag="true"
+    drag-selector=".modal-banner"
     :resize="true"
     :max-height="700"
     :max-width="700"
@@ -30,12 +31,14 @@
             label="이름"
             required
             outlined="true"
+            v-on:click.stop.self
           ></v-text-field>
           <v-text-field
             v-show="isBookmark"
             v-model="bookmarkUpdateModalInfo.url"
             label="URL"
             required
+            v-on:click.stop
           >
           </v-text-field>
         </v-form>
@@ -125,6 +128,7 @@ export default defineComponent({
 
 .modal-banner {
   display: flex;
+  width: 100%;
   justify-content: space-between;
 }
 </style>

--- a/src/newtab/components/UpdateModal.vue
+++ b/src/newtab/components/UpdateModal.vue
@@ -1,0 +1,130 @@
+<template>
+  <vue-final-modal
+    v-model="bookmarkUpdateShow"
+    classes="modal-container"
+    content-class="modal-content"
+    overlay-class="modal-overlay"
+    :drag="true"
+    :resize="true"
+    :max-height="700"
+    :max-width="700"
+    :hide-overlay="true"
+    :click-to-close="false"
+    :esc-to-close="false"
+    :prevent-click="true"
+    z-index="9999"
+  >
+    <v-card class="modal-inner" outlined title elevation="7">
+      <v-card-header class="modal-banner bg-primary">
+        <div class="modal__title d-flex">{{ modalTitle }}</div>
+        <button class="modal__close" @click="closeModal">
+          <v-icon>mdi-close</v-icon>
+        </button>
+      </v-card-header>
+
+      <v-card-text class="text-h5 font-weight-bold">
+        <v-form :key="bookmarkUpdateModalInfo">
+          <v-text-field
+            v-model="bookmarkUpdateModalInfo.title"
+            counter
+            label="이름"
+            required
+            outlined="true"
+          ></v-text-field>
+          <v-text-field
+            v-show="isBookmark"
+            v-model="bookmarkUpdateModalInfo.url"
+            label="URL"
+            required
+          >
+          </v-text-field>
+        </v-form>
+      </v-card-text>
+
+      <v-card-actions>
+        <v-btn @click="update"> 저장 </v-btn>
+
+        <v-btn @click="closeModal"> 취소 </v-btn>
+      </v-card-actions>
+    </v-card>
+  </vue-final-modal>
+</template>
+<script lang="ts">
+import { defineComponent } from "vue";
+import { Item } from "../../shared/types/store";
+import { mapActions, mapGetters, mapMutations } from "vuex";
+import {
+  GET_BOOKMARK_UPDATE_INFO,
+  SET_BOOKMARK_UPDATE_INFO,
+  GET_BOOKMARK_UPDATE_SHOW,
+  SET_BOOKMARK_UPDATE_SHOW,
+  CLOSE_BOOKMARK_UPDATE,
+} from "../store/modules/updateModal";
+
+import { RENEW_BOOKMARK_TREE } from "../store/index";
+import BookmarkApi from "../utils/bookmarkApi";
+export default defineComponent({
+  computed: {
+    ...mapGetters([GET_BOOKMARK_UPDATE_SHOW, GET_BOOKMARK_UPDATE_INFO]),
+    bookmarkUpdateModalInfo: {
+      get(): Item {
+        return this[GET_BOOKMARK_UPDATE_INFO];
+      },
+      set(val: Item) {
+        this[SET_BOOKMARK_UPDATE_INFO](val);
+      },
+    },
+    bookmarkUpdateShow: {
+      get(): boolean {
+        return this[GET_BOOKMARK_UPDATE_SHOW];
+      },
+      set(val: boolean) {
+        this[SET_BOOKMARK_UPDATE_SHOW](val);
+      },
+    },
+    isBookmark(): boolean {
+      return this[GET_BOOKMARK_UPDATE_INFO].url;
+    },
+    modalTitle(): string {
+      return this.isBookmark ? "북마크 수정" : "폴더 이름 바꾸기";
+    },
+  },
+  methods: {
+    ...mapActions([CLOSE_BOOKMARK_UPDATE, RENEW_BOOKMARK_TREE]),
+    ...mapMutations([SET_BOOKMARK_UPDATE_INFO, SET_BOOKMARK_UPDATE_SHOW]),
+    closeModal() {
+      this[CLOSE_BOOKMARK_UPDATE]();
+    },
+    async update() {
+      const { id, title, url } = this.bookmarkUpdateModalInfo;
+      const updateSuccessful = await BookmarkApi.update(id, title, url);
+      if (updateSuccessful) {
+        this[RENEW_BOOKMARK_TREE]();
+        this[CLOSE_BOOKMARK_UPDATE]();
+      }
+    },
+  },
+});
+</script>
+
+<style scoped>
+::v-deep .modal-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+::v-deep .modal-content {
+  position: relative;
+  width: 500px;
+  height: 500px;
+}
+
+.modal-inner {
+  border: 1px solid lightgray;
+}
+
+.modal-banner {
+  display: flex;
+  justify-content: space-between;
+}
+</style>

--- a/src/newtab/pages/Desktop.vue
+++ b/src/newtab/pages/Desktop.vue
@@ -17,12 +17,14 @@
   <ContextMenu v-model:show="showContextMenu" :position="contextMenuPosition">
     <div class="context-menu-item">Create Folder</div>
   </ContextMenu>
+  <UpdateModal />
 </template>
 
 <script lang="ts">
 import { defineComponent } from "vue";
 import { Item, modalInfo } from "../../shared/types/store";
 import Bookshelf from "../components/Bookshelf.vue";
+import UpdateModal from "../components/UpdateModal.vue";
 import BookshelfModal from "../components/BookshelfModal.vue";
 import ContextMenu, { Position } from "../components/ContextMenu.vue";
 import { mapGetters } from "vuex";
@@ -31,7 +33,7 @@ import { GET_BOOKMARK_TREE } from "../store";
 const OFFSET = 2;
 
 export default defineComponent({
-  components: { Bookshelf, BookshelfModal, ContextMenu },
+  components: { Bookshelf, BookshelfModal, ContextMenu, UpdateModal },
   data: () => ({
     modals: [] as modalInfo[],
     maxZIndex: 1000,

--- a/src/newtab/store/index.ts
+++ b/src/newtab/store/index.ts
@@ -2,9 +2,10 @@ import updateModal from "./modules/updateModal";
 
 import { Item } from "@/shared/types/store";
 import { createStore } from "vuex";
-
+import BookmarkApi from "../utils/bookmarkApi";
 export const GET_BOOKMARK_TREE = "getBookmarkTree";
 export const SET_BOOKMARK_TREE = "setBookmarkTree";
+export const RENEW_BOOKMARK_TREE = "renewBookmarkTree";
 
 export interface RootState {
   bookmarkTree: Item[];
@@ -23,6 +24,11 @@ const store = createStore<RootState>({
   mutations: {
     [SET_BOOKMARK_TREE](state, _bookmarkTree) {
       state.bookmarkTree = _bookmarkTree;
+    },
+  },
+  actions: {
+    async [RENEW_BOOKMARK_TREE]({ commit }) {
+      commit(SET_BOOKMARK_TREE, await BookmarkApi.getTree());
     },
   },
 });

--- a/src/newtab/store/index.ts
+++ b/src/newtab/store/index.ts
@@ -1,13 +1,17 @@
+import updateModal from "./modules/updateModal";
+
 import { Item } from "@/shared/types/store";
 import { createStore } from "vuex";
 
 export const GET_BOOKMARK_TREE = "getBookmarkTree";
 export const SET_BOOKMARK_TREE = "setBookmarkTree";
-export interface State {
+
+export interface RootState {
   bookmarkTree: Item[];
 }
 
-const store = createStore<State>({
+const store = createStore<RootState>({
+  modules: { updateModal },
   state: {
     bookmarkTree: [] as Item[],
   },

--- a/src/newtab/store/modules/updateModal.ts
+++ b/src/newtab/store/modules/updateModal.ts
@@ -3,6 +3,7 @@ import { RootState } from "../index";
 
 export const GET_BOOKMARK_UPDATE_INFO = "getBookmarkUpdateInfo";
 export const SET_BOOKMARK_UPDATE_INFO = "setBookmarkUpdateInfo";
+
 export const GET_BOOKMARK_UPDATE_SHOW = "getBookmarkUpdateShow";
 export const SET_BOOKMARK_UPDATE_SHOW = "setBookmarkUpdateShow";
 
@@ -16,7 +17,7 @@ export interface State {
 }
 
 const updateModalModule: Module<State, RootState> = {
-  namespaced: true,
+  namespaced: false,
   state: {
     updateModalInfo: {
       id: "",
@@ -28,17 +29,17 @@ const updateModalModule: Module<State, RootState> = {
 
   getters: {
     [GET_BOOKMARK_UPDATE_SHOW](state) {
-      return state.updateModalInfo;
+      return state.updateModalShow;
     },
     [GET_BOOKMARK_UPDATE_INFO](state) {
       return state.updateModalInfo;
     },
   },
   mutations: {
-    [GET_BOOKMARK_UPDATE_SHOW](state, _updateModalInfo) {
+    [SET_BOOKMARK_UPDATE_INFO](state, _updateModalInfo) {
       state.updateModalInfo = { ..._updateModalInfo };
     },
-    [GET_BOOKMARK_UPDATE_SHOW](state, _updateModalShow) {
+    [SET_BOOKMARK_UPDATE_SHOW](state, _updateModalShow) {
       state.updateModalShow = _updateModalShow;
     },
   },

--- a/src/newtab/store/modules/updateModal.ts
+++ b/src/newtab/store/modules/updateModal.ts
@@ -1,0 +1,47 @@
+import { Module } from "vuex";
+import { RootState } from "../index";
+
+export const GET_BOOKMARK_UPDATE_INFO = "getBookmarkUpdateInfo";
+export const SET_BOOKMARK_UPDATE_INFO = "setBookmarkUpdateInfo";
+export const GET_BOOKMARK_UPDATE_SHOW = "getBookmarkUpdateShow";
+export const SET_BOOKMARK_UPDATE_SHOW = "setBookmarkUpdateShow";
+
+export interface State {
+  updateModalInfo: {
+    id: string;
+    url: string;
+    title: string;
+  };
+  updateModalShow: boolean;
+}
+
+const updateModalModule: Module<State, RootState> = {
+  namespaced: true,
+  state: {
+    updateModalInfo: {
+      id: "",
+      url: "",
+      title: "",
+    },
+    updateModalShow: false,
+  },
+
+  getters: {
+    [GET_BOOKMARK_UPDATE_SHOW](state) {
+      return state.updateModalInfo;
+    },
+    [GET_BOOKMARK_UPDATE_INFO](state) {
+      return state.updateModalInfo;
+    },
+  },
+  mutations: {
+    [GET_BOOKMARK_UPDATE_SHOW](state, _updateModalInfo) {
+      state.updateModalInfo = { ..._updateModalInfo };
+    },
+    [GET_BOOKMARK_UPDATE_SHOW](state, _updateModalShow) {
+      state.updateModalShow = _updateModalShow;
+    },
+  },
+};
+
+export default updateModalModule;

--- a/src/newtab/store/modules/updateModal.ts
+++ b/src/newtab/store/modules/updateModal.ts
@@ -55,7 +55,6 @@ const updateModalModule: Module<State, RootState> = {
     },
 
     [CLOSE_BOOKMARK_UPDATE]({ commit }) {
-      console.log("close");
       commit(SET_BOOKMARK_UPDATE_INFO, {
         id: "",
         url: undefined,

--- a/src/newtab/store/modules/updateModal.ts
+++ b/src/newtab/store/modules/updateModal.ts
@@ -55,12 +55,12 @@ const updateModalModule: Module<State, RootState> = {
     },
 
     [CLOSE_BOOKMARK_UPDATE]({ commit }) {
+      commit(SET_BOOKMARK_UPDATE_SHOW, false);
       commit(SET_BOOKMARK_UPDATE_INFO, {
         id: "",
         url: undefined,
         title: "",
       });
-      commit(SET_BOOKMARK_UPDATE_SHOW, false);
     },
   },
 };

--- a/src/newtab/store/modules/updateModal.ts
+++ b/src/newtab/store/modules/updateModal.ts
@@ -1,18 +1,23 @@
 import { Module } from "vuex";
 import { RootState } from "../index";
 
+import { Item } from "../../../shared/types/store";
 export const GET_BOOKMARK_UPDATE_INFO = "getBookmarkUpdateInfo";
 export const SET_BOOKMARK_UPDATE_INFO = "setBookmarkUpdateInfo";
 
 export const GET_BOOKMARK_UPDATE_SHOW = "getBookmarkUpdateShow";
 export const SET_BOOKMARK_UPDATE_SHOW = "setBookmarkUpdateShow";
 
+export const CLOSE_BOOKMARK_UPDATE = "closeBookmarkUpdateAction";
+
+export const OPEN_BOOKMARK_UPDATE = "openBookmarkUpdateAction";
+export interface IUpdateModalInfo {
+  id: string;
+  url?: string | undefined;
+  title: string;
+}
 export interface State {
-  updateModalInfo: {
-    id: string;
-    url: string;
-    title: string;
-  };
+  updateModalInfo: IUpdateModalInfo;
   updateModalShow: boolean;
 }
 
@@ -21,7 +26,7 @@ const updateModalModule: Module<State, RootState> = {
   state: {
     updateModalInfo: {
       id: "",
-      url: "",
+      url: undefined,
       title: "",
     },
     updateModalShow: false,
@@ -36,11 +41,27 @@ const updateModalModule: Module<State, RootState> = {
     },
   },
   mutations: {
-    [SET_BOOKMARK_UPDATE_INFO](state, _updateModalInfo) {
+    [SET_BOOKMARK_UPDATE_INFO](state, _updateModalInfo: IUpdateModalInfo) {
       state.updateModalInfo = { ..._updateModalInfo };
     },
-    [SET_BOOKMARK_UPDATE_SHOW](state, _updateModalShow) {
+    [SET_BOOKMARK_UPDATE_SHOW](state, _updateModalShow: boolean) {
       state.updateModalShow = _updateModalShow;
+    },
+  },
+  actions: {
+    [OPEN_BOOKMARK_UPDATE]({ commit }, updateModalInfo) {
+      commit(SET_BOOKMARK_UPDATE_INFO, updateModalInfo);
+      commit(SET_BOOKMARK_UPDATE_SHOW, true);
+    },
+
+    [CLOSE_BOOKMARK_UPDATE]({ commit }) {
+      console.log("close");
+      commit(SET_BOOKMARK_UPDATE_INFO, {
+        id: "",
+        url: undefined,
+        title: "",
+      });
+      commit(SET_BOOKMARK_UPDATE_SHOW, false);
     },
   },
 };


### PR DESCRIPTION
updateModal 컴포넌트 추가
- 수정 모달에서 다루는 타겟 데이터, 모달 출력 여부는 모두 스토어에서 관리
- 관련 과정을 action함수들을 최대한 활용하여 추후 리팩토링에서 코드 수정이 적도록 작성
---
- 트리데이터를 갱신하는 action함수 추가
---
- ContextMenu에서 'edit' 버튼 클릭 시 updateModal 보이도록 연결

---
- 논의 됐었던 bookmark api의 update 관련하여 
- 별도의 updateTitle,updateUrl은 사용하지 않아도 될 것 같습니다.