### PR TITLE
Desktop, BookshelfModal 스크롤 기능

### DIFF
--- a/src/newtab/NewTab.vue
+++ b/src/newtab/NewTab.vue
@@ -24,4 +24,7 @@ export default defineComponent({
 #newtab {
   height: 100vh;
 }
+html {
+  overflow-y: auto !important;
+}
 </style>

--- a/src/newtab/components/BookshelfModal.vue
+++ b/src/newtab/components/BookshelfModal.vue
@@ -32,10 +32,12 @@
           <v-icon>mdi-close</v-icon>
         </button>
       </v-card-header>
-      <Bookshelf
-        @routeInFolder="routeInFolder"
-        :folderItem="viewItem"
-      ></Bookshelf>
+      <div class="v-card-content">
+        <Bookshelf
+          @routeInFolder="routeInFolder"
+          :folderItem="viewItem"
+        ></Bookshelf>
+      </div>
     </v-card>
   </vue-final-modal>
 </template>
@@ -137,5 +139,13 @@ export default defineComponent({
 .modal-banner {
   display: flex;
   justify-content: space-between;
+}
+.v-card {
+  display: flex;
+  flex-direction: column;
+}
+.v-card-content {
+  flex: 1;
+  overflow-y: auto;
 }
 </style>


### PR DESCRIPTION
closes #34 

## Summary

Desktop, BookShelfModal이 컨텐츠가 많을 경우 스크롤이 되도록 수정합니다. 

## Descriptions

- overflow가 있는 경우에만 스크롤바를 나타내기 위해서 overflow-y: auto로 스타일 적용
- vuetify의 CSS reset에서 Desktop의 스크롤 여부를 결정하는 html의 overflow를 scroll로 세팅함
  - html DOM의 specificity를 올릴 좋은 방법이 없어서 !important를 사용했는데, 더 좋은 방법 있으면 의견 부탁드려요