### PR TITLE
refactor :  bookshelf 데이터 id 기반으로 컴포넌트에서 관리

### DIFF
--- a/src/newtab/NewTab.vue
+++ b/src/newtab/NewTab.vue
@@ -5,19 +5,11 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 import Desktop from "./pages/Desktop.vue";
-import BookmarkApi from "./utils/bookmarkApi";
-import { mapMutations } from "vuex";
-import { SET_BOOKMARK_TREE } from "./store";
 
 export default defineComponent({
   name: "Popup",
   components: { Desktop },
-  async mounted() {
-    this.setBookmarkTree(await BookmarkApi.getTree());
-  },
-  methods: {
-    ...mapMutations([SET_BOOKMARK_TREE]),
-  },
+  methods: {},
 });
 </script>
 <style lang="scss">

--- a/src/newtab/components/Bookshelf.vue
+++ b/src/newtab/components/Bookshelf.vue
@@ -54,44 +54,56 @@ import Favicon from "./Favicon.vue";
 import { mapActions } from "vuex";
 import { OPEN_BOOKMARK_UPDATE } from "../store/modules/updateModal";
 import { openContextMenu } from "../utils/contextMenu";
+import BookmarkApi from "../utils/bookmarkApi";
 
 export default defineComponent({
   components: { Favicon },
   props: {
-    folderItem: {
-      type: Object as PropType<chrome.bookmarks.BookmarkTreeNode>,
+    id: {
+      type: String,
       required: true,
+    },
+    isDesktop: {
+      type: Boolean,
+      required: false,
+      default: false,
     },
   },
   data: () => ({
-    targetItem: {} as Item,
+    folderItem: {} as Item,
   }),
+  async mounted() {
+    this.refresh();
+  },
   methods: {
     ...mapMutations([OPEN_BOOKSHELF_MODALS]),
     ...mapActions([OPEN_BOOKMARK_UPDATE]), // updateMODAL
     openBookmarkModal() {
       // TODO: 네이밍 변경(ex. updateModal)
-      this[OPEN_BOOKMARK_UPDATE](this.targetItem);
+      this[OPEN_BOOKMARK_UPDATE](this.folderItem);
     },
     onDblClickFolder(item: Item) {
-      const { id, title, children = [], parentId } = item;
-      const isRootItem = parentId === "1";
-      if (isRootItem) {
-        this._openBookshelfModal(title, children, id);
+      const { id, title } = item;
+      // const isRootItem = this.id === "1";
+      if (this.isDesktop) {
+        this._openBookshelfModal(id, title);
       } else {
-        this.routeInFolder({ id, title, children });
+        this.routeInFolder(id, title);
       }
     },
-    routeInFolder(folderItem: FolderItem) {
-      this.$emit("routeInFolder", folderItem);
+    routeInFolder(id: string, title: string) {
+      this.$emit("routeInFolder", id);
     },
-    _openBookshelfModal(title: string, children: Item[], id: string) {
-      this.openBookshelfModal({ title, children, id });
+    _openBookshelfModal(id: string, title: string) {
+      this.openBookshelfModal({ id, title });
     },
     openUrl(id: string, url: string) {
       window.open(url, "_blank")?.focus();
     },
     openContextMenu,
+    async refresh() {
+      this.folderItem = await BookmarkApi.getSubTree(this.id);
+    },
   },
 });
 </script>

--- a/src/newtab/components/BookshelfModal.vue
+++ b/src/newtab/components/BookshelfModal.vue
@@ -19,7 +19,7 @@
       outlined
       title
       elevation="7"
-      @mousedown.capture="focusBookshelfModal(initId)"
+      @mousedown.capture="focusBookshelfModal(bookshelfModalId)"
     >
       <v-card-header class="modal-banner bg-primary">
         <div class="modal__title d-flex">
@@ -28,27 +28,33 @@
           </button>
           <v-breadcrumbs :items="folderRoute"></v-breadcrumbs>
         </div>
-        <button class="modal__close" @click="closeBookshelfModal(initId)">
+        <button
+          class="modal__close"
+          @click="closeBookshelfModal(bookshelfModalId)"
+        >
           <v-icon>mdi-close</v-icon>
         </button>
       </v-card-header>
       <Bookshelf
+        v-if="viewItem.id"
+        :key="viewItem.id"
         @routeInFolder="routeInFolder"
-        :folderItem="viewItem"
+        :id="viewItem.id"
+        :title="viewItem.title"
       ></Bookshelf>
     </v-card>
   </vue-final-modal>
 </template>
 <script lang="ts">
-import { defineComponent, PropType } from "vue";
+import { defineComponent } from "vue";
 import { mapMutations } from "vuex";
-import { FolderItem, Item } from "../../shared/types/store";
+import { FolderItem } from "../../shared/types/store";
 import {
   CLOSE_BOOKSHELF_MODALS,
   FOCUS_BOOKSHELF_MODALS,
 } from "../store/modules/bookshelfModal";
 import Bookshelf from "./Bookshelf.vue";
-
+import BookmarkApi from "../utils/bookmarkApi";
 interface BreadCrumb {
   disabled: boolean;
   text: string | number;
@@ -57,15 +63,11 @@ interface BreadCrumb {
 export default defineComponent({
   components: { Bookshelf },
   props: {
-    initId: {
+    bookshelfModalId: {
       type: String,
       required: true,
     },
-    initItems: {
-      type: Array as PropType<Item[]>,
-      required: true,
-    },
-    initTitle: {
+    id: {
       type: String,
       required: true,
     },
@@ -82,10 +84,7 @@ export default defineComponent({
   },
   computed: {
     showBackward() {
-      return this.folderRoute.length > 1;
-    },
-    viewItem() {
-      return this.folderItems[this.folderItems.length - 1];
+      return this.viewItem.id !== "1";
     },
     _showBookshelfModal() {
       return this.showBookshelfModal;
@@ -96,21 +95,32 @@ export default defineComponent({
         text: item.title,
       }));
     },
+    viewItem() {
+      return this.folderItems[this.folderItems.length - 1];
+    },
   },
+
   created() {
-    this.folderItems.push({
-      id: this.initId,
-      title: this.initTitle,
-      children: this.initItems,
-    });
+    this.routeInFolder(this.id);
   },
   methods: {
     ...mapMutations([CLOSE_BOOKSHELF_MODALS, FOCUS_BOOKSHELF_MODALS]),
-    routeInFolder(folderItem: FolderItem) {
-      this.folderItems.push(folderItem);
+    async routeInFolder(id: string) {
+      this.folderItems.push({ id, title: "" });
+      await this.routePahtRefresh();
     },
-    backward() {
+    async backward() {
       this.folderItems.pop();
+      if (this.folderItems.length == 0) {
+        this.folderItems.push({ id: "1", title: "" });
+      }
+      await this.routePahtRefresh();
+    },
+    async routePahtRefresh() {
+      const ids = this.folderItems.map((item) => {
+        return item.id;
+      });
+      if (ids.length > 0) this.folderItems = await BookmarkApi.get(ids);
     },
   },
 });

--- a/src/newtab/components/BookshelfModalContainer.vue
+++ b/src/newtab/components/BookshelfModalContainer.vue
@@ -1,10 +1,10 @@
 <template>
   <BookshelfModal
-    v-for="({ title, children, zIndex }, id) in modals"
-    :key="id"
-    :initId="id"
-    :initItems="children"
-    :initTitle="title"
+    v-for="({ zIndex, title, id }, bookshelfModalId) in modals"
+    :key="bookshelfModalId"
+    :id="id"
+    :bookshelfModalId="bookshelfModalId"
+    :title="title"
     :zIndex="zIndex"
   ></BookshelfModal>
 </template>

--- a/src/newtab/pages/Desktop.vue
+++ b/src/newtab/pages/Desktop.vue
@@ -1,5 +1,5 @@
 <template>
-  <Bookshelf :folderItem="bookmarkTreeRoot"></Bookshelf>
+  <Bookshelf id="1" :isDesktop="true"></Bookshelf>
   <CreateFolderModal></CreateFolderModal>
   <BookshelfModalContainer></BookshelfModalContainer>
   <ContextMenu />

--- a/src/newtab/store/modules/bookshelfModal.ts
+++ b/src/newtab/store/modules/bookshelfModal.ts
@@ -10,9 +10,7 @@ export const CLOSE_BOOKSHELF_MODALS = "closeBookshelfModal";
 
 export interface BookshelfModalParams {
   id: string;
-  title: string;
   zIndex: number;
-  children: Item[];
 }
 
 export interface State {
@@ -21,7 +19,7 @@ export interface State {
 }
 
 export interface BookshelfModals {
-  [key: string]: { title: string; children: Item[]; zIndex: number };
+  [key: string]: { zIndex: number; id: string };
 }
 
 const OFFSET = 2;
@@ -38,13 +36,12 @@ const createbookshelfModal: Module<State, RootState> = {
   },
   mutations: {
     [OPEN_BOOKSHELF_MODALS](state, bookshelfModalData: BookshelfModalParams) {
-      const { id, title, children } = bookshelfModalData;
-      state.bookshelfModals[id] = {
-        title,
-        children,
+      const { id } = bookshelfModalData;
+      const currentTime = new Date().toString();
+      state.bookshelfModals[currentTime] = {
+        id: id,
         zIndex: (state.currentZIndex += OFFSET),
       };
-      console.debug("open bookshelfModal >> ", id);
     },
     [FOCUS_BOOKSHELF_MODALS](state, bookshelfModalId: string) {
       state.bookshelfModals[bookshelfModalId].zIndex = state.currentZIndex +=

--- a/src/newtab/utils/bookmarkApi.ts
+++ b/src/newtab/utils/bookmarkApi.ts
@@ -1,6 +1,17 @@
-import { Item } from "@/shared/types/store";
+import { Item, FolderItem } from "@/shared/types/store";
 
 class BookmarkApi {
+  static async get(ids: string[]): Promise<FolderItem[]> {
+    const bookMarks = await chrome.bookmarks.get(ids);
+
+    return bookMarks;
+  }
+
+  static async getSubTree(id: string): Promise<Item> {
+    const bookMarks = await chrome.bookmarks.getSubTree(id);
+    return bookMarks[0];
+  }
+
   static async getTree(): Promise<Item> {
     const bookMarks = await chrome.bookmarks.getTree();
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/shared/types/store.ts
+++ b/src/shared/types/store.ts
@@ -9,5 +9,4 @@ export type modalInfo = {
 export interface FolderItem {
   title: string;
   id: string;
-  children: Item[];
 }


### PR DESCRIPTION
- bookshelf에 id props가 추가되었습니다. id를 기반으로 데이터를 컴포넌트 내부에서 가져옵니다.
- bookshelf key에 viewitem.id가 추가되어 라우트 변경시 새롭게 created됩니다.
---
- modal id를 datetime으로 변경하여 동일한 경로 폴더가 여러개 열릴 수 있습니다.
 ---
- 폴더에서 backward를 통해 루트로 갈수 있도록 했습니다.
- id=1이 모달에서도 보여질 수 있기 때문에 bookshelf props에 isDesktop이 추가되었습니다. 
---
- 폴더 라우트 이동시 라우트 경로의 내용을 refresh합니다. (다른 모달 및 크롬에서 폴더이름 수정시 -> 라우트 이동시에 반영)
---
작동 순서 정리
- (bookShelf)@routeInFolder : 들어갈 id 전달 =>
- (BookshelfModal)routeInfolder => folderRoute에 id 추가 + 전체 path title refresh => viewItem변경  =>
- (bookShelf) 변경된 id로 recreated

Closes #27 
--



    