### PR TITLE
전역 Bookmark 상태 제거

### DIFF
--- a/src/newtab/components/CreateFolderModal.vue
+++ b/src/newtab/components/CreateFolderModal.vue
@@ -20,8 +20,8 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
-import { mapActions, mapGetters, mapMutations } from "vuex";
-import { RENEW_BOOKMARK_TREE, SET_BOOKMARK_TREE } from "../store";
+import { mapGetters, mapMutations } from "vuex";
+import { SET_BOOKMARK_TREE } from "../store";
 import {
   GET_BOOKMARK_CREATE_INFO,
   GET_BOOKMARK_CREATE_SHOW,
@@ -63,7 +63,6 @@ export default defineComponent({
         store.commit(SET_REFRESH_TARGET, this.createFolderModalInfo.parentId);
         this.resetCreateFolderModalInfo();
         this.setCreateFolderModalShow(false);
-        this.renewBookmarkTree();
       }
     },
     closeCreateFolderModal() {
@@ -73,9 +72,6 @@ export default defineComponent({
       resetCreateFolderModalInfo: RESET_BOOKMARK_CREATE_INFO,
       setCreateFolderModalShow: SET_BOOKMARK_CREATE_SHOW,
       setBookmarkTree: SET_BOOKMARK_TREE,
-    }),
-    ...mapActions({
-      renewBookmarkTree: RENEW_BOOKMARK_TREE,
     }),
   },
 });

--- a/src/newtab/components/UpdateModal.vue
+++ b/src/newtab/components/UpdateModal.vue
@@ -65,7 +65,6 @@ import {
 } from "../store/modules/updateModal";
 import store, { SET_REFRESH_TARGET } from "../store/index";
 
-import { RENEW_BOOKMARK_TREE } from "../store/index";
 import BookmarkApi from "../utils/bookmarkApi";
 export default defineComponent({
   computed: {
@@ -94,7 +93,7 @@ export default defineComponent({
     },
   },
   methods: {
-    ...mapActions([CLOSE_BOOKMARK_UPDATE, RENEW_BOOKMARK_TREE]),
+    ...mapActions([CLOSE_BOOKMARK_UPDATE]),
     ...mapMutations([SET_BOOKMARK_UPDATE_INFO, SET_BOOKMARK_UPDATE_SHOW]),
     closeModal() {
       this[CLOSE_BOOKMARK_UPDATE]();

--- a/src/newtab/pages/Desktop.vue
+++ b/src/newtab/pages/Desktop.vue
@@ -9,9 +9,7 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 import Bookshelf from "../components/Bookshelf.vue";
-import { mapGetters } from "vuex";
 import UpdateModal from "../components/UpdateModal.vue";
-import { GET_BOOKMARK_TREE_ROOT } from "../store";
 import CreateFolderModal from "../components/CreateFolderModal.vue";
 import BookshelfModalContainer from "../components/BookshelfModalContainer.vue";
 import ContextMenuContainer from "../components/ContextMenu/ContextMenuContainer.vue";
@@ -23,11 +21,6 @@ export default defineComponent({
     BookshelfModalContainer,
     ContextMenuContainer,
     UpdateModal,
-  },
-  computed: {
-    ...mapGetters({
-      bookmarkTreeRoot: GET_BOOKMARK_TREE_ROOT,
-    }),
   },
 });
 </script>

--- a/src/newtab/store/index.ts
+++ b/src/newtab/store/index.ts
@@ -1,5 +1,4 @@
 import updateModal from "./modules/updateModal";
-import BookmarkApi from "../utils/bookmarkApi";
 
 import { Item } from "@/shared/types/store";
 import { createStore } from "vuex";
@@ -26,31 +25,14 @@ const store = createStore<State>({
     contextMenu,
     updateModal,
   },
-  state: {
-    bookmarkTree: { title: "placeholder", id: "-1", children: [] } as Item,
-  },
   getters: {
-    [GET_BOOKMARK_TREE_CHILDREN](state) {
-      return state.bookmarkTree.children;
-    },
-    [GET_BOOKMARK_TREE_ROOT](state) {
-      return state.bookmarkTree;
-    },
     [GET_REFRESH_TARGET](state) {
       return state.refreshTargetId;
     },
   },
   mutations: {
-    [SET_BOOKMARK_TREE](state, _bookmarkTree) {
-      state.bookmarkTree = _bookmarkTree;
-    },
     [SET_REFRESH_TARGET](state, id) {
       state.refreshTargetId = id;
-    },
-  },
-  actions: {
-    async [RENEW_BOOKMARK_TREE]({ commit }) {
-      commit(SET_BOOKMARK_TREE, await BookmarkApi.getTree());
     },
   },
 });


### PR DESCRIPTION
- 전역 상태에서, Bookmark 상태가 사용되지 않으므로 삭제하였습니다.
  
   refresh를 위해 사용되는 refreshTargetId는 남겨두었습니다.