### PR TITLE
폴더 삭제 시 BookshelfModal close 기능 추가 / 변수명 리팩토링

### DIFF
--- a/src/newtab/components/BookshelfModal.vue
+++ b/src/newtab/components/BookshelfModal.vue
@@ -20,7 +20,7 @@
         outlined
         title
         elevation="7"
-        @mousedown.capture="focusBookshelfModal(bookshelfModalId)"
+        @mousedown.capture="focusBookshelfModal(timeStampId)"
       >
         <v-card-header class="modal-banner bg-primary">
           <div class="modal__title d-flex">
@@ -35,7 +35,7 @@
           </div>
           <button
             class="modal__close"
-            @click="closeBookshelfModal(bookshelfModalId)"
+            @click="closeBookshelfModal(timeStampId)"
           >
             <v-icon>mdi-close</v-icon>
           </button>
@@ -75,7 +75,7 @@ interface BreadCrumb {
 export default defineComponent({
   components: { Bookshelf },
   props: {
-    bookshelfModalId: {
+    timeStampId: {
       type: String,
       required: true,
     },

--- a/src/newtab/components/BookshelfModalContainer.vue
+++ b/src/newtab/components/BookshelfModalContainer.vue
@@ -1,9 +1,9 @@
 <template>
   <BookshelfModal
-    v-for="({ zIndex, title, id }, bookshelfModalId) in modals"
-    :key="bookshelfModalId"
+    v-for="({ zIndex, title, id }, timeStampId) in modals"
+    :key="timeStampId"
     :id="id"
-    :bookshelfModalId="bookshelfModalId"
+    :timeStampId="timeStampId"
     :title="title"
     :zIndex="zIndex"
   ></BookshelfModal>

--- a/src/newtab/components/ContextMenu/ContextMenuContent.vue
+++ b/src/newtab/components/ContextMenu/ContextMenuContent.vue
@@ -32,6 +32,7 @@ import { SET_CONTEXT_MENU_SHOW_STATE } from "../../store/modules/contextMenu";
 import { SET_REFRESH_TARGET } from "../../store/index";
 import BookmarkApi from "../../utils/bookmarkApi";
 import store from "../../store/index";
+import { CLOSE_BOOKSHELF_MODALS_BY_ID } from "@/newtab/store/modules/bookshelfModal";
 
 export default defineComponent({
   props: {
@@ -67,6 +68,7 @@ export default defineComponent({
       if (confirm("Are you sure you want to delete?")) {
         await BookmarkApi.recursiveRemove(target.item.id);
         store.commit(SET_REFRESH_TARGET, target.item.parentId);
+        store.commit(CLOSE_BOOKSHELF_MODALS_BY_ID, target.item.id);
       }
       store.commit(SET_CONTEXT_MENU_SHOW_STATE, false);
     },

--- a/src/newtab/store/modules/bookshelfModal.ts
+++ b/src/newtab/store/modules/bookshelfModal.ts
@@ -87,7 +87,6 @@ const createbookshelfModal: Module<State, RootState> = {
         (timeStampId: string) =>
           state.bookshelfModals[timeStampId].id === id ? timeStampId : false
       );
-      console.log(targetTimestampIds);
       targetTimestampIds.forEach(
         (targetTimeStampId) => delete state.bookshelfModals[targetTimeStampId]
       );

--- a/src/newtab/store/modules/bookshelfModal.ts
+++ b/src/newtab/store/modules/bookshelfModal.ts
@@ -6,6 +6,7 @@ export const GET_BOOKSHELF_MODALS = "getBookshelfModal";
 export const OPEN_BOOKSHELF_MODALS = "openBookshelfModal";
 export const FOCUS_BOOKSHELF_MODALS = "focusBookshelfModal";
 export const CLOSE_BOOKSHELF_MODALS = "closeBookshelfModal";
+export const CLOSE_BOOKSHELF_MODALS_BY_ID = "closeBookshelfModalById";
 
 export const GET_BOOKSHELF_MODALS_CURRENT_POSITION =
   "getBookshelfModalsCurrentPosition";
@@ -80,6 +81,17 @@ const createbookshelfModal: Module<State, RootState> = {
     [CLOSE_BOOKSHELF_MODALS](state, timeStampId: string) {
       delete state.bookshelfModals[timeStampId];
       console.debug("close bookshelfModal >> ", timeStampId);
+    },
+    [CLOSE_BOOKSHELF_MODALS_BY_ID](state, id: string) {
+      const targetTimestampIds = Object.keys(state.bookshelfModals).filter(
+        (timeStampId: string) =>
+          state.bookshelfModals[timeStampId].id === id ? timeStampId : false
+      );
+      console.log(targetTimestampIds);
+      targetTimestampIds.forEach(
+        (targetTimeStampId) => delete state.bookshelfModals[targetTimeStampId]
+      );
+      console.debug("close bookshelfModal >> ", id);
     },
     [UPDATE_BOOKSHELF_MODALS_CURRENT_POSITION](state, position: Position) {
       const targetPosition = {

--- a/src/newtab/store/modules/bookshelfModal.ts
+++ b/src/newtab/store/modules/bookshelfModal.ts
@@ -66,20 +66,20 @@ const createbookshelfModal: Module<State, RootState> = {
   mutations: {
     [OPEN_BOOKSHELF_MODALS](state, bookshelfModalData: BookshelfModalParams) {
       const { id } = bookshelfModalData;
-      const currentTime = new Date().toString();
-      state.bookshelfModals[currentTime] = {
+      const timeStampId = new Date().toString();
+      state.bookshelfModals[timeStampId] = {
         id: id,
         zIndex: (state.currentZIndex += OFFSET),
       };
+      console.debug("open bookshelfModal >> ", timeStampId);
     },
-    [FOCUS_BOOKSHELF_MODALS](state, bookshelfModalId: string) {
-      state.bookshelfModals[bookshelfModalId].zIndex = state.currentZIndex +=
-        OFFSET;
-      console.debug("focus bookshelfModal >> ", bookshelfModalId);
+    [FOCUS_BOOKSHELF_MODALS](state, timeStampId: string) {
+      state.bookshelfModals[timeStampId].zIndex = state.currentZIndex += OFFSET;
+      console.debug("focus bookshelfModal >> ", timeStampId);
     },
-    [CLOSE_BOOKSHELF_MODALS](state, bookshelfModalId: string) {
-      delete state.bookshelfModals[bookshelfModalId];
-      console.debug("open bookshelfModal >> ", bookshelfModalId);
+    [CLOSE_BOOKSHELF_MODALS](state, timeStampId: string) {
+      delete state.bookshelfModals[timeStampId];
+      console.debug("close bookshelfModal >> ", timeStampId);
     },
     [UPDATE_BOOKSHELF_MODALS_CURRENT_POSITION](state, position: Position) {
       const targetPosition = {


### PR DESCRIPTION
- 폴더 삭제시 BookshelfModal close 기능 추가

   전역 컴포넌트인 ContextMenuContent에서 timeStamp 기반 id를 접근할 수 없으므로 id로 삭제하는 mutation 추가

- BookshelfModal의 상태 키인 bookshelfModalId => timeStampId로 이름 변경
  
   BookMark의 고유 Id인 `id` 변수와 헷갈릴 것 같아서 이름 변경