### PR TITLE
fix: Bookmark Hover시 부모 폴더명 툴팁 삭제

### DIFF
--- a/src/newtab/components/BookshelfModal.vue
+++ b/src/newtab/components/BookshelfModal.vue
@@ -47,7 +47,6 @@
             :key="viewItem.id"
             @routeInFolder="routeInFolder"
             :id="viewItem.id"
-            :title="viewItem.title"
           ></Bookshelf>
         </div>
       </v-card>


### PR DESCRIPTION
- Bookmark Hover 시 해당 파일/ 폴더 이름이 아닌, 부모 폴더 이름이  나오는 현상 수정

  BookshelfModal에서 Bookshelf에 설정하는 title값 삭제

clsoe #91 