### PR TITLE
fix: Tooltip이 bookshelf modal 영역을 확장시키던 문제 해결

### DIFF
--- a/src/newtab/components/Bookshelf.vue
+++ b/src/newtab/components/Bookshelf.vue
@@ -6,43 +6,44 @@
     "
   >
     <div v-for="item in folderItem.children" v-bind:key="item.id">
-      <Tooltip :text="item.title">
-        <v-btn
-          class="btn"
-          tile
-          elevation="0"
-          @click="onClickFolder(item)"
-          v-if="item.children"
-          @contextmenu.prevent.stop="
-            openContextMenu($event, { item: item, type: 'FOLDER' })
-          "
-        >
-          <div class="item-container">
-            <v-icon class="item-icon">mdi-folder</v-icon>
-            <p class="item-title">
-              {{ item.title }}
-            </p>
-          </div>
-        </v-btn>
-
-        <v-btn
-          v-else
-          class="btn"
-          tile
-          elevation="0"
-          @click="openUrl(item.id, item.url)"
-          @contextmenu.prevent.stop="
-            openContextMenu($event, { item: item, type: 'FILE' })
-          "
-        >
-          <div class="item-container">
-            <Favicon :url="item.url" />
-            <p class="item-title">
-              {{ item.title }}
-            </p>
-          </div>
-        </v-btn>
-      </Tooltip>
+      <v-btn
+        class="btn"
+        tile
+        elevation="0"
+        v-if="item.children"
+        @click="onClickFolder(item)"
+        @mouseover="openTooltip(item.title, $event)"
+        @mouseleave="closeTooltip()"
+        @contextmenu.prevent.stop="
+          openContextMenu($event, { item: item, type: 'FOLDER' })
+        "
+      >
+        <div class="item-container">
+          <v-icon class="item-icon">mdi-folder</v-icon>
+          <p class="item-title">
+            {{ item.title }}
+          </p>
+        </div>
+      </v-btn>
+      <v-btn
+        v-else
+        class="btn"
+        tile
+        elevation="0"
+        @click="openUrl(item.id, item.url)"
+        @mouseover="openTooltip(item.title, $event)"
+        @mouseleave="closeTooltip()"
+        @contextmenu.prevent.stop="
+          openContextMenu($event, { item: item, type: 'FILE' })
+        "
+      >
+        <div class="item-container">
+          <Favicon :url="item.url" />
+          <p class="item-title">
+            {{ item.title }}
+          </p>
+        </div>
+      </v-btn>
     </div>
   </div>
 </template>
@@ -57,10 +58,14 @@ import { OPEN_BOOKMARK_UPDATE } from "../store/modules/updateModal";
 import store, { GET_REFRESH_TARGET, SET_REFRESH_TARGET } from "../store/index";
 import { openContextMenu } from "../utils/contextMenu";
 import BookmarkApi from "../utils/bookmarkApi";
-import Tooltip from "../components/Tooltip.vue";
+import {
+  SET_TOOLTIP_POSITION,
+  SET_TOOLTIP_SHOW,
+  SET_TOOLTIP_TEXT,
+} from "../store/modules/tooltip";
 
 export default defineComponent({
-  components: { Favicon, Tooltip },
+  components: { Favicon },
   props: {
     id: {
       type: String,
@@ -90,7 +95,12 @@ export default defineComponent({
     this.refresh();
   },
   methods: {
-    ...mapMutations([OPEN_BOOKSHELF_MODALS]),
+    ...mapMutations([
+      OPEN_BOOKSHELF_MODALS,
+      SET_TOOLTIP_POSITION,
+      SET_TOOLTIP_TEXT,
+      SET_TOOLTIP_SHOW,
+    ]),
     ...mapActions([OPEN_BOOKMARK_UPDATE]), // updateMODAL
     openBookmarkModal() {
       // TODO: 네이밍 변경(ex. updateModal)
@@ -117,6 +127,24 @@ export default defineComponent({
     openContextMenu,
     async refresh() {
       this.folderItem = await BookmarkApi.getSubTree(this.id);
+    },
+    openTooltip(title: string, event: MouseEvent) {
+      const targetElement = event.target as HTMLElement;
+      const buttonElement = targetElement.closest("button");
+      if (!buttonElement) return;
+
+      const boundingRect = buttonElement.getBoundingClientRect();
+      const position = {
+        x: boundingRect.x,
+        y: boundingRect.y + boundingRect.height,
+      };
+
+      this[SET_TOOLTIP_POSITION](position);
+      this[SET_TOOLTIP_TEXT](title);
+      this[SET_TOOLTIP_SHOW](true);
+    },
+    closeTooltip() {
+      this[SET_TOOLTIP_SHOW](false);
     },
   },
 });

--- a/src/newtab/components/Tooltip.vue
+++ b/src/newtab/components/Tooltip.vue
@@ -1,7 +1,9 @@
 <template>
-  <div class="tooltip" v-if="tooltipShow">
-    <span class="text">{{ tooltipText }}</span>
-  </div>
+  <Transition>
+    <div class="tooltip" v-if="tooltipShow">
+      <span class="text">{{ tooltipText }}</span>
+    </div>
+  </Transition>
 </template>
 <script lang="ts">
 import { defineComponent } from "vue";
@@ -48,8 +50,6 @@ export default defineComponent({
   padding: 4px;
   pointer-events: none;
   word-wrap: break-word;
-  opacity: 0.85;
-  transition-property: opacity, transform;
   transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
   transition-duration: 75ms;
   transform: translateX(-50%) translateX(40px) translateY(5px);
@@ -69,5 +69,16 @@ export default defineComponent({
   border-width: 5px;
   border-style: solid;
   border-color: transparent transparent gray transparent;
+}
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
+}
+.v-enter-active {
+  transition-delay: 1000ms;
+}
+.v-enter-to,
+.v-leave-from {
+  opacity: 0.85;
 }
 </style>

--- a/src/newtab/components/Tooltip.vue
+++ b/src/newtab/components/Tooltip.vue
@@ -1,62 +1,60 @@
 <template>
-  <div class="tooltip-container">
-    <div class="slot-container">
-      <slot />
-    </div>
-    <div class="tooltip">
-      <span class="text">{{ text }}</span>
-    </div>
+  <div class="tooltip" v-if="tooltipShow">
+    <span class="text">{{ tooltipText }}</span>
   </div>
 </template>
-<script>
-export default {
+<script lang="ts">
+import { defineComponent } from "vue";
+import { mapGetters } from "vuex";
+import {
+  GET_TOOLTIP_POSITION,
+  GET_TOOLTIP_SHOW,
+  GET_TOOLTIP_TEXT,
+} from "../store/modules/tooltip";
+
+export default defineComponent({
   props: {
     text: {
       type: String,
       required: true,
     },
   },
-};
+  computed: {
+    ...mapGetters({
+      tooltipPosition: GET_TOOLTIP_POSITION,
+      tooltipText: GET_TOOLTIP_TEXT,
+      tooltipShow: GET_TOOLTIP_SHOW,
+    }),
+    tooltipPositionPx() {
+      return {
+        x: `${this.tooltipPosition.x}px`,
+        y: `${this.tooltipPosition.y}px`,
+      };
+    },
+  },
+});
 </script>
-
 <style scoped>
-.slot-container {
-  width: 100%;
-}
-.tooltip-container {
-  position: relative;
-  display: inline-block;
-}
-
-.tooltip-container:hover .tooltip {
-  opacity: 0.85;
-
-  transition: opacity;
-  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
-  transition-duration: 150ms;
-  transition-delay: 1000ms;
-}
-
 .tooltip {
-  top: 108%;
-  left: 40px;
+  top: v-bind("tooltipPositionPx.y");
+  left: v-bind("tooltipPositionPx.x");
   color: #ffffff;
   text-align: center;
   border-radius: 4px;
   font-size: 0.875rem;
   line-height: 1.6;
-  min-width: 100%;
-  max-width: 200%;
+  min-width: 80px;
+  max-width: 160px;
   padding: 4px;
   pointer-events: none;
-  transition-property: opacity, transform;
   word-wrap: break-word;
-  opacity: 0;
+  opacity: 0.85;
+  transition-property: opacity, transform;
   transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
   transition-duration: 75ms;
-  position: absolute;
-  z-index: 1000;
-  transform: translateX(-50%);
+  transform: translateX(-50%) translateX(40px) translateY(5px);
+  position: fixed;
+  z-index: 10000;
   background: gray;
 }
 .text {

--- a/src/newtab/pages/Desktop.vue
+++ b/src/newtab/pages/Desktop.vue
@@ -5,6 +5,7 @@
     <BookshelfModalContainer></BookshelfModalContainer>
     <ContextMenuContainer />
     <UpdateModal />
+    <Tooltip />
   </div>
 </template>
 
@@ -17,6 +18,7 @@ import CreateFolderModal from "../components/CreateFolderModal.vue";
 import BookshelfModalContainer from "../components/BookshelfModalContainer.vue";
 import ContextMenuContainer from "../components/ContextMenu/ContextMenuContainer.vue";
 import { Item } from "@/shared/types/store";
+import Tooltip from "../components/Tooltip.vue";
 
 export default defineComponent({
   components: {
@@ -25,6 +27,7 @@ export default defineComponent({
     BookshelfModalContainer,
     ContextMenuContainer,
     UpdateModal,
+    Tooltip,
   },
   mounted() {
     setBookmarksEventHandlers();

--- a/src/newtab/store/index.ts
+++ b/src/newtab/store/index.ts
@@ -5,6 +5,7 @@ import { createStore } from "vuex";
 import createModalModule from "./modules/createFolderModal";
 import createBookshelfModal from "./modules/bookshelfModal";
 import contextMenu from "./modules/contextMenu";
+import tooltip from "./modules/tooltip";
 
 export const GET_BOOKMARK_TREE_CHILDREN = "getBookmarkTree";
 export const GET_BOOKMARK_TREE_ROOT = "getBookmarkTreeRoot";
@@ -24,6 +25,7 @@ const store = createStore<State>({
     createBookshelfModal,
     contextMenu,
     updateModal,
+    tooltip,
   },
   getters: {
     [GET_REFRESH_TARGET](state) {

--- a/src/newtab/store/modules/tooltip.ts
+++ b/src/newtab/store/modules/tooltip.ts
@@ -1,0 +1,51 @@
+import { Module } from "vuex";
+import { State as RootState } from "../index";
+
+export const GET_TOOLTIP_POSITION = "getTooltipPosition";
+export const SET_TOOLTIP_POSITION = "setTooltipPosition";
+export const GET_TOOLTIP_TEXT = "getTooltipText";
+export const SET_TOOLTIP_TEXT = "setTooltipText";
+export const GET_TOOLTIP_SHOW = "getTooltipShow";
+export const SET_TOOLTIP_SHOW = "setTooltipShow";
+
+export interface State {
+  tooltipPosition: {
+    x: number;
+    y: number;
+  };
+  tooltipText: string;
+  tooltipShow: boolean;
+}
+
+const createModalModule: Module<State, RootState> = {
+  namespaced: false,
+  state: {
+    tooltipPosition: { x: 0, y: 0 },
+    tooltipText: "",
+    tooltipShow: false,
+  },
+  getters: {
+    [GET_TOOLTIP_POSITION](state) {
+      return state.tooltipPosition;
+    },
+    [GET_TOOLTIP_TEXT](state) {
+      return state.tooltipText;
+    },
+    [GET_TOOLTIP_SHOW](state) {
+      return state.tooltipShow;
+    },
+  },
+  mutations: {
+    [SET_TOOLTIP_POSITION](state, _tooltipPosition) {
+      state.tooltipPosition = _tooltipPosition;
+    },
+    [SET_TOOLTIP_TEXT](state, _tooltipText) {
+      state.tooltipText = _tooltipText;
+    },
+    [SET_TOOLTIP_SHOW](state, _tooltipShow) {
+      state.tooltipShow = _tooltipShow;
+    },
+  },
+};
+
+export default createModalModule;


### PR DESCRIPTION
## Problem
- absolute를 사용한다 하더라도, 부모의 스크롤 영역을 툴팁이 넘어설 수 없음
- absolute를 사용한다 하더라도, 부모의 스크롤 영역의 높이에 영향을 줌

## Solution
- Modal 영역을 벗어날 수 있도록 Tooltip 엘리먼트를 상위 DOM으로 이동
- Vuex Store를 통해 hover 된 아이템의 위치와 텍스트 정보 전달

## Other
- Transition 기능을 이용하여 툴팁 노출 시 지연시간 구현 (제거 시에는 지연시간 없음)