### PR TITLE
feat: Favicon 응답 사이즈가 16일 경우 처리

### DIFF
--- a/src/newtab/components/Favicon.vue
+++ b/src/newtab/components/Favicon.vue
@@ -33,8 +33,11 @@ export default defineComponent({
     this.imgSrc = PREFIX + this.url;
   },
   methods: {
-    loadImage() {
+    loadImage({ target }: { target: HTMLImageElement }) {
       this.isLoading = false;
+      if (target.naturalWidth === 16) {
+        this.imgSrc = "";
+      }
     },
 
     notFoundImage() {


### PR DESCRIPTION
Favicon 응답 사이즈가 16일 경우 처리
- Favicon을 요청했을 때, 응답 결과가 없음녀 16x16 사이즈의 기본 이미지와 404 response 코드로 응답
- 응답 결과 이미지가 16x16일 경우 실패로 간주하여, image.src = ""로 설정, 기본 이미지가 나오도록
---
- before
   ![image](https://user-images.githubusercontent.com/55068119/164230007-2c1d56e5-517c-4f3f-a353-d130648e6201.png)
- after
   ![image](https://user-images.githubusercontent.com/55068119/164229869-e0421f99-9101-41d9-a3e3-dc8fca18c2f2.png)
---
### 논의사항
- favicon 응답이 16x16인 실제 favicon 이미지를 내려줄 경우에도 기본 이미지로 대체되게 됩니다.

   - 응답이 16x16인 이미지 예시
      ![image](https://user-images.githubusercontent.com/55068119/164231098-dff7484e-c00f-4ffd-a884-e8ae639ce8ea.png)
