### PR TITLE
부모 -> 자식 폴더 이동 예외 처리

### DIFF
--- a/src/newtab/components/Bookshelf.vue
+++ b/src/newtab/components/Bookshelf.vue
@@ -307,42 +307,28 @@ export default defineComponent({
         }
 
         if (isBetweenContainer) {
-          // if (
-          //   changingElId === targetGridContainerParentId ||
-          //   targetElId === changingElId
-          // ) {
-
           /**
-           * 1. targetEl이 있을 경우 && changingEl가 targetEl의 부모일 경우, 즉시 리턴 -> targetEl가 targetGridContainerParent의 자식이므로 필요 X ==> 폴더 내의 폴더 Item으로 드래그 했을 경우 ==> 실패
-           * 2. targetEl이 없고, targetGridContainer가 있을 경우 && changingEl가 targetGridContainerParent의 부모일 경우, 즉시 리턴 ==> 폴더 내의 빈공간드래그 했을 경우 ==> 실패
-           *
-           * 0. changingEl이 folderItems에 있을 경우, 즉시 리턴
+           * 1. .modal-inner로 폴더 상위 찾기
+           * 2. .modal-inner의 자식 v-breadcrumbs 찾기
+           * 3. data-id로 id들 찾기
+           * 4. validation (target 있으면 target까지, 없으면 breadcrumb만)
            */
-          /**
-           *
-           * - folderItems(breadcrumbs)는 실패 => 이벤트를 처리하는 주체가 changingEl이 있던 container라서 changingEl의 id가 folderItems에 없어서 가져올수가 없다.
-           *
-           * - breadcrumb이 있는 dom의 이름을 뽑아서 할수도 없다 -> key가 이름이 아니라 id이어서
-           *    v-breadcrumbs-item을 이용해서 id를 dom에다 집어넣어주고, targetContainer에서 breadcrumb을 찾아서 검색
-           * - 결국 전체탐색 -> 자식에서 부모로 할수도 없다. -> 부모에서 자식으로 전체 탐색 (폴더만)
-           */
-          const isTargetIsParentOfContainer = props.folderItems?.some(
-            (folderItem) => folderItem.id === changingElId
-          );
+          const result = targetGridContainerEl
+            .closest(".modal-inner")
+            ?.querySelector(".folder-route")
+            ?.querySelectorAll("[data-id]");
 
-          console.log(
-            "=============== isTargetIsParentOfContainer",
-            props.folderItems,
-            targetEl,
-            targetElId,
-            isTargetIsParentOfContainer
-          );
+          if (result) {
+            const isDropError = [...result]
+              .map((el) => (el as HTMLElement).dataset.id as string)
+              .some((id) => id === changingElId);
 
-          if (isTargetIsParentOfContainer) {
+            if (isDropError || targetElId === changingElId) {
             changingEl.style.gridColumn = String(originCol);
             changingEl.style.gridRow = String(originRow);
             fixDom(changingEl);
             return;
+            }
           }
 
           // 빈공간

--- a/src/newtab/components/Bookshelf.vue
+++ b/src/newtab/components/Bookshelf.vue
@@ -313,13 +313,13 @@ export default defineComponent({
            * 3. data-id로 id들 찾기
            * 4. validation (target 있으면 target까지, 없으면 breadcrumb만)
            */
-          const result = targetGridContainerEl
+          const targetGridContainerBreadcrumbs = targetGridContainerEl
             .closest(".modal-inner")
             ?.querySelector(".folder-route")
             ?.querySelectorAll("[data-id]");
 
-          if (result) {
-            const isDropError = [...result]
+          if (targetGridContainerBreadcrumbs) {
+            const isDropError = [...targetGridContainerBreadcrumbs]
               .map((el) => (el as HTMLElement).dataset.id as string)
               .some((id) => id === changingElId);
 

--- a/src/newtab/components/Bookshelf.vue
+++ b/src/newtab/components/Bookshelf.vue
@@ -324,16 +324,15 @@ export default defineComponent({
               .some((id) => id === changingElId);
 
             if (isDropError || targetElId === changingElId) {
-            changingEl.style.gridColumn = String(originCol);
-            changingEl.style.gridRow = String(originRow);
-            fixDom(changingEl);
-            return;
+              changingEl.style.gridColumn = String(originCol);
+              changingEl.style.gridRow = String(originRow);
+              fixDom(changingEl);
+              return;
             }
           }
 
           // 빈공간
           if (!targetEl || !targetElId) {
-            setChangingElPosition(changingEl);
             saveLayoutToDB();
             /**
              * @ERROR
@@ -350,14 +349,12 @@ export default defineComponent({
           // 폴더 위
           // 폴더에서 같은 값을 북마크 move에 넘기는 경우 크롬 자체가 죽어버리는 현상 발견(이유는 정확히 파악 못했음)
           if (targetElType === "FOLDER" && changingElId !== targetElId) {
-            setChangingElPositionAuto(changingEl);
             await BookmarkApi.move(changingElId, targetElId);
             return;
           }
 
           // 파일 위
           if (targetElType === "FILE") {
-            setChangingElPositionAuto(changingEl);
             await BookmarkApi.move(changingElId, targetGridContainerParentId); // 폴더에서 같은 값을 북마크 move에 넘기는 경우 크롬 자체가 죽어버리는 현상 발견(이유는 정확히 파악 못했음)
             return;
           }
@@ -385,12 +382,6 @@ export default defineComponent({
           target.style.gridColumn = String(holderCol);
           target.dataset.row = String(holderRow);
           target.dataset.col = String(holderCol);
-          fixDom(target);
-        }
-
-        function setChangingElPositionAuto(target: HTMLElement) {
-          target.style.gridRow = "auto";
-          target.style.gridColumn = "auto";
           fixDom(target);
         }
       };

--- a/src/newtab/components/BookshelfModal.vue
+++ b/src/newtab/components/BookshelfModal.vue
@@ -31,7 +31,8 @@
             >
               <v-icon>mdi-keyboard-backspace</v-icon>
             </button>
-            <v-breadcrumbs :items="folderRoute"></v-breadcrumbs>
+            <v-breadcrumbs class="folder-route" :items="folderRoute">
+            </v-breadcrumbs>
           </div>
           <button
             class="modal__close"
@@ -107,6 +108,7 @@ export default defineComponent({
       return this.folderItems.map((item) => ({
         disabled: false,
         text: item.title,
+        "data-id": item.id,
       }));
     },
     viewItem() {

--- a/src/newtab/components/BookshelfModal.vue
+++ b/src/newtab/components/BookshelfModal.vue
@@ -47,6 +47,7 @@
             :key="viewItem.id"
             @routeInFolder="routeInFolder"
             :id="viewItem.id"
+            :folderItems="folderItems"
           ></Bookshelf>
         </div>
       </v-card>
@@ -147,6 +148,7 @@ export default defineComponent({
       UPDATE_BOOKSHELF_MODALS_CURRENT_POSITION,
     ]),
     async routeInFolder(id: string) {
+      console.log("========= folderItems : ", this.folderItems);
       this.folderItems.push({ id, title: "" });
       await this.routePathRefresh();
     },

--- a/src/newtab/components/BookshelfModal.vue
+++ b/src/newtab/components/BookshelfModal.vue
@@ -150,7 +150,6 @@ export default defineComponent({
       UPDATE_BOOKSHELF_MODALS_CURRENT_POSITION,
     ]),
     async routeInFolder(id: string) {
-      console.log("========= folderItems : ", this.folderItems);
       this.folderItems.push({ id, title: "" });
       await this.routePathRefresh();
     },


### PR DESCRIPTION
- 부모 폴더에서 자식 폴더로 이동할 경우 bookmark api에서 에러가 발생하여 브라우저가 멈추므로 예외처리

- target 폴더의 경로를 얻어오기 위해 breadcrumb에 id 추가