### PR TITLE
16이하 사이즈 아이콘 캐릭터로 대체

### DIFF
--- a/src/newtab/components/Bookshelf.vue
+++ b/src/newtab/components/Bookshelf.vue
@@ -51,7 +51,7 @@
         "
       >
         <div class="item-container">
-          <Favicon :url="item.url" />
+          <Favicon :url="item.url" :replaceChar="item.title.charAt(0)" />
           <p class="item-title">
             {{ item.title }}
           </p>

--- a/src/newtab/components/Favicon.vue
+++ b/src/newtab/components/Favicon.vue
@@ -11,7 +11,11 @@
       @load="loadImage"
       @error="notFoundImage"
       alt="icon"
+      v-if="showImgIcon"
     />
+    <icon :class="`favicon`" v-else>
+      {{ replaceChar }}
+    </icon>
   </div>
 </template>
 <script lang="ts">
@@ -27,13 +31,24 @@ export default defineComponent({
       type: String,
       required: true,
     },
+    replaceChar: String,
   },
-  data: () => ({ isLoading: true, loadingImage: LoadingImg, imgSrc: "" }),
+  data: () => ({
+    isLoading: true,
+    loadingImage: LoadingImg,
+    imgSrc: "",
+    showImgIcon: true,
+    randomColor: `#${Math.floor(Math.random() * 16777215).toString(16)}`,
+  }),
   created() {
     this.imgSrc = PREFIX + this.url;
   },
   methods: {
-    loadImage() {
+    loadImage(e: Event) {
+      const targetImg = e.target as HTMLImageElement;
+      if (targetImg.width <= 16 || targetImg.height <= 16) {
+        this.showImgIcon = false;
+      }
       this.isLoading = false;
     },
 
@@ -55,6 +70,11 @@ export default defineComponent({
   .favicon {
     width: 48px;
     height: 48px;
+    font-size: 48px;
+
+    font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+    font-weight: 600;
+    color: v-bind("randomColor");
   }
 
   .disable {


### PR DESCRIPTION
- 16사이즈 이하 아이콘 랜덤 색상의 텍스트로 대체
-
<img width="347" alt="스크린샷 2022-07-03 오후 5 40 18" src="https://user-images.githubusercontent.com/41819176/177032106-f5967295-60cb-4505-9df0-88adaa10c938.png">

- 추후 svg로 대체 논의 필요