### PR TITLE
DB 초기화 시 row, col이 Infinity로 계산되어 레이아웃이 깨지는 오류 수정

### DIFF
--- a/src/newtab/components/composition/setupBookshelfLayout.ts
+++ b/src/newtab/components/composition/setupBookshelfLayout.ts
@@ -17,8 +17,10 @@ interface Props {
 
 const appendLayoutData = async (folderItem: Item): Promise<Item> => {
   const layoutData = await layoutDB.getLayout(folderItem.id);
+  console.log("==== layoutData", layoutData);
   folderItem.children?.forEach((item: Item) => {
     const { row, col } = layoutData[item.id] ?? {};
+    console.log("====== row col", row, col);
     item.row = row;
     item.col = col;
     item.type = item.children ? "FOLDER" : "FILE";
@@ -92,12 +94,16 @@ export const setupBookshelfLayout = (props: Props): SetupBookshelfLayout => {
 
     const parentId = originalItem.parentId as string;
 
-    // row column을 DB에 삽입
-    layoutDB.setItemLayoutById({ id, parentId, row, col });
-
-    // 저장된 초기 row, col 값을 folderItem에 반영
-    originalItem.row = row;
-    originalItem.col = col;
+    // row column이 Infinity일 경우 Auto로 셋팅, 아닐경우 DB에 삽입
+    if (row === -Infinity || col === -Infinity) {
+      originalItem.row = "auto";
+      originalItem.col = "auto";
+    } else {
+      layoutDB.setItemLayoutById({ id, parentId, row, col });
+      // 저장된 초기 row, col 값을 folderItem에 반영
+      originalItem.row = row;
+      originalItem.col = col;
+    }
   };
 
   return {

--- a/src/shared/types/store.ts
+++ b/src/shared/types/store.ts
@@ -1,6 +1,6 @@
 export interface Item extends chrome.bookmarks.BookmarkTreeNode {
-  row?: number;
-  col?: number;
+  row?: number | string;
+  col?: number | string;
   type?: string;
 }
 


### PR DESCRIPTION
- DB 초기화 후 새로고침 시 여러 컴포넌트간 재 렌더링 영향으로 row, col이 Infinity로 계산됨.

   계산 결과가 Infinity일 경우, auto를 임시로 삽입해주어 이후 계산에서 정상적인 row,col로 계산되도록 수정
